### PR TITLE
test: add cypress stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 Test Framework for UI tests at Satellite.im
 
 In order to run those tests:
+
 - you can either use this repo and use `cd main` go to the main branch or use the main repo and use any branch
 - `yarn dev` - to start localhost
 - `npx cypress open` - to open cypress
-
 
 inside Cypress, you can either run a test separately or click on the run integrations specs button to run them all

--- a/cypress.json
+++ b/cypress.json
@@ -1,5 +1,0 @@
-{
-    "projectId": "4offi6",
-    "baseUrl": "http://localhost:3000",
-    "numTestsKeptInMemory": 0
-}

--- a/integration/chat-features.js
+++ b/integration/chat-features.js
@@ -1,12 +1,11 @@
 const faker = require('faker')
 const randomWord = faker.lorem.word() // generate random word
-const randomNumber = faker.datatype.number() // generate random word
+const randomNumber = faker.datatype.number() // generate random number
 const randomMessage = faker.lorem.sentence() // generate random sentence
 const textToPaste = 'copy paste stuff'
 
 it('Chat - Send stuff on chat', () => {
   cy.importAccount()
-  //Cypress.on('uncaught:exception', (err, runnable) => false) // temporary until AP-270 gets fixed
   cy.contains('aaaaa').click() //clicks on user name
   cy.get('.messageuser').type(randomMessage)
   cy.get('.messageuser').type('{enter}') //to send out a written message
@@ -28,6 +27,5 @@ it('Chat - Send stuff on chat', () => {
   cy.get('.messageuser').type(randomWord)
   cy.get('.messageuser').type('{enter}')
   */
-  // add copy paste when copy paste is fixed - AP-108
-  // add edit message when edit message is added - AP-39
+  // add copy paste test
 })

--- a/integration/chat-features.js
+++ b/integration/chat-features.js
@@ -1,11 +1,12 @@
 const faker = require('faker')
 const randomWord = faker.lorem.word() // generate random word
+const randomNumber = faker.datatype.number() // generate random word
 const randomMessage = faker.lorem.sentence() // generate random sentence
 const textToPaste = 'copy paste stuff'
 
 it('Chat - Send stuff on chat', () => {
   cy.importAccount()
-  Cypress.on('uncaught:exception', (err, runnable) => false) // temporary until AP-270 gets fixed
+  //Cypress.on('uncaught:exception', (err, runnable) => false) // temporary until AP-270 gets fixed
   cy.contains('aaaaa').click() //clicks on user name
   cy.get('.messageuser').type(randomMessage)
   cy.get('.messageuser').type('{enter}') //to send out a written message
@@ -16,6 +17,11 @@ it('Chat - Send stuff on chat', () => {
   cy.get('.messageuser').type('{enter}')
   cy.contains('😄')
   cy.contains(randomMessage).rightclick()
+  cy.contains('Edit Message').click()
+  cy.get('.edit-message-body-input > p').click()
+  cy.get('.edit-message-body-input > p').type(randomNumber)
+  cy.get('.edit-message-body-input > p').type('{enter}')
+  cy.contains(randomNumber)
   /*
   cy.contains('Reply').click() //to reply on a thread - to be added when AP-271 is fixed
   cy.contains('Reply to')

--- a/integration/import-account-negative-tests.js
+++ b/integration/import-account-negative-tests.js
@@ -1,0 +1,28 @@
+it('Verify error when adding a wrong order passphrase', () => {
+  cy.visit('/')
+    cy.get('[data-cy=add-input]').type('test001', { log: false })
+    cy.get('[data-cy=submit-input]').click()
+    cy.contains('Import Account').click()
+    cy.get('[data-cy=add-passphrase]').type(
+      'over tilt regret diamond rubber example there fire roof sheriff always boring',
+      { log: false },
+    )
+    cy.get('[data-cy=add-passphrase]').type('{enter}')
+    cy.contains('Recover Account').click()
+    cy.contains('We were unable to verify your passphrase. Please check it and try again.').should(
+      'be.visible',
+    )
+  })
+
+it('Verify behavior when adding less than 12 words', () => {
+  cy.visit('/')
+    cy.get('[data-cy=add-input]').type('test001', { log: false })
+    cy.get('[data-cy=submit-input]').click()
+    cy.contains('Import Account').click()
+    cy.get('[data-cy=add-passphrase]').type(
+      'over tilt regret diamond rubber example there fire roof sheriff always',
+      { log: false },
+    )
+    cy.get('[data-cy=add-passphrase]').type('{enter}')
+    cy.get('.recover-account').should('be.disabled')
+  })

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,9 @@
       "dependencies": {
         "cypress-file-upload": "^5.0.8",
         "faker": "^5.5.3"
+      },
+      "devDependencies": {
+        "cypress-localstorage-commands": "^1.6.1"
       }
     },
     "node_modules/@cypress/request": {
@@ -545,6 +548,18 @@
       },
       "peerDependencies": {
         "cypress": ">3.0.0"
+      }
+    },
+    "node_modules/cypress-localstorage-commands": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/cypress-localstorage-commands/-/cypress-localstorage-commands-1.6.1.tgz",
+      "integrity": "sha512-rvXCB0iLzC3i9y91XH4N2I55NicH62gQk5z/APblCjnNR3wWTbDs8svC7GvE1fjt9AMIHSQm1RfWx037y+TciQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "cypress": ">=2.1.0"
       }
     },
     "node_modules/dashdash": {
@@ -2194,6 +2209,13 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/cypress-file-upload/-/cypress-file-upload-5.0.8.tgz",
       "integrity": "sha512-+8VzNabRk3zG6x8f8BWArF/xA/W0VK4IZNx3MV0jFWrJS/qKn8eHfa5nU73P9fOQAgwHFJx7zjg4lwOnljMO8g==",
+      "requires": {}
+    },
+    "cypress-localstorage-commands": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/cypress-localstorage-commands/-/cypress-localstorage-commands-1.6.1.tgz",
+      "integrity": "sha512-rvXCB0iLzC3i9y91XH4N2I55NicH62gQk5z/APblCjnNR3wWTbDs8svC7GvE1fjt9AMIHSQm1RfWx037y+TciQ==",
+      "dev": true,
       "requires": {}
     },
     "dashdash": {

--- a/package.json
+++ b/package.json
@@ -8,5 +8,8 @@
   "dependencies": {
     "cypress-file-upload": "^5.0.8",
     "faker": "^5.5.3"
+  },
+  "devDependencies": {
+    "cypress-localstorage-commands": "^1.6.1"
   }
 }

--- a/support/commands.js
+++ b/support/commands.js
@@ -51,9 +51,11 @@ Cypress.Commands.add('importAccount', () => {
   )
   cy.get('[data-cy=add-passphrase]').type('{enter}')
   cy.contains('Recover Account').click()
+  Cypress.on('uncaught:exception', (err, runnable) => false) // temporary until AP-48 gets fixed
   cy.contains('Working on the space station', { timeout: 60000 }).should(
     'be.visible',
   )
 })
 
 import 'cypress-file-upload'
+import 'cypress-localstorage-commands'

--- a/yarn.lock
+++ b/yarn.lock
@@ -291,7 +291,12 @@
   "resolved" "https://registry.npmjs.org/cypress-file-upload/-/cypress-file-upload-5.0.8.tgz"
   "version" "5.0.8"
 
-"cypress@>3.0.0":
+"cypress-localstorage-commands@^1.6.1":
+  "integrity" "sha512-rvXCB0iLzC3i9y91XH4N2I55NicH62gQk5z/APblCjnNR3wWTbDs8svC7GvE1fjt9AMIHSQm1RfWx037y+TciQ=="
+  "resolved" "https://registry.npmjs.org/cypress-localstorage-commands/-/cypress-localstorage-commands-1.6.1.tgz"
+  "version" "1.6.1"
+
+"cypress@>=2.1.0", "cypress@>3.0.0":
   "integrity" "sha512-Jn26Tprhfzh/a66Sdj9SoaYlnNX6Mjfmj5PHu2a7l3YHXhrgmavM368wjCmgrxC6KHTOv9SpMQGhAJn+upDViA=="
   "resolved" "https://registry.npmjs.org/cypress/-/cypress-9.2.0.tgz"
   "version" "9.2.0"


### PR DESCRIPTION
- Removes `cypress.json` file, added on the main repo here - https://github.com/Satellite-im/Core-PWA/pull/910
- Adds the following tests:

Edit message
Verify error when adding a wrong order passphrase
Verify behavior when adding less than 12 words

- Adds `cypress-localstorage-commands lib`
- Adds `faker.datatype.number` to generate random number
- Minor updates