### PR TITLE
test(cypress): successful account creation after trying NSFW image

### DIFF
--- a/integration/create-account-negative-tests.js
+++ b/integration/create-account-negative-tests.js
@@ -14,34 +14,20 @@ it('Try to create account with PIN less than 5 digits', () => {
 })
 
 it('Try to create account without username', () => {
-  cy.visit('/')
-  cy.get('[data-cy=add-input]').type('test001', { log: false })
-  cy.get('[data-cy=submit-input]').click()
-  cy.get('.is-primary > #custom-cursor-area').click()
-  cy.contains('Continue').click()
-  cy.contains('I Saved It').click()
-  Cypress.on('uncaught:exception', (err, runnable) => false) // temporary until AP-48 gets fixed
+  //Creating pin, clicking on buttons to continue to user data screen
+  cy.accountCreationFirstSteps()
   cy.get('[data-cy=sign-in-button]').click()
   cy.contains('Username must be at least 5 characters.')
 })
 
 it('Try to create account with NSFW image', () => {
   //Creating pin, clicking on buttons to continue to user data screen
-  cy.visit('/')
-  cy.get('[data-cy=add-input]').type('test001', { log: false })
-  cy.get('[data-cy=submit-input]').click()
-  cy.get('.is-primary > #custom-cursor-area').click()
-  cy.contains('Continue').click()
-  cy.contains('I Saved It').click()
-  Cypress.on('uncaught:exception', (err, runnable) => false) // temporary until AP-48 gets fixed
+  cy.accountCreationFirstSteps()
   //Adding random data in user input fields
-  cy.get('[data-cy=username-input]').type(randomName)
-  cy.contains('Status')
-  cy.get('[data-cy=status-input]').type(randomStatus)
+  cy.accountCreationFillRandomData()
   //Attempting to add NSFW image and validating error message is displayed
   const filepath = 'images/negative-create-account-test.png'
-  cy.get('.is-outlined > #custom-cursor-area').click()
-  cy.get('.input-file').attachFile(filepath)
+  cy.accountCreationAddImage(filepath)
   cy.get('.red', { timeout: 10000 }).should(
     'have.text',
     'Unable to upload file/s due to NSFW status',

--- a/integration/create-account.js
+++ b/integration/create-account.js
@@ -1,6 +1,7 @@
 const faker = require('faker')
 const randomName = faker.internet.userName(name) // generate random name
 const randomStatus = faker.lorem.word() // generate random status
+const filepathCorrect = 'images/logo.png'
 
 it('Create Account', () => {
   cy.visit('/')
@@ -45,17 +46,47 @@ it('Create Account', () => {
   cy.get('.title').should('contain', 'Recovery Seed')
   cy.get('#custom-cursor-area').click()
   cy.contains('Customize how the world sees you, choose something memorable.', {
-    timeout: 5000,
+    timeout: 10000,
   }).should('be.visible')
   cy.contains('Username')
   Cypress.on('uncaught:exception', (err, runnable) => false) // temporary until AP-48 gets fixed
   cy.get('[data-cy=username-input]').type(randomName)
   cy.contains('Status')
   cy.get('[data-cy=status-input]').type(randomStatus)
-  const filepath = 'images/logo.png'
   cy.get('.is-outlined > #custom-cursor-area').click()
-  cy.get('.input-file').attachFile(filepath)
+  cy.get('.input-file').attachFile(filepathCorrect)
   cy.contains('Crop').click()
+  cy.get('[data-cy=sign-in-button]').click()
+  cy.contains('Linking Satellites...')
+})
+
+it('Create account with non-NSFW after attempting to load a NSFW image', () => {
+  /*
+  user signs up
+  goes to the sign up add image section
+  adds a NSFW image
+  returns error
+  uploads a non-NSFW image
+  works fine
+  user is able to sign up 
+  assert user was able to sign up
+  */
+  //Creating pin, clicking on buttons to continue to user data screen
+  cy.accountCreationFirstSteps()
+  //Adding random data in user input fields
+  cy.accountCreationFillRandomData()
+  //Attempting to add NSFW image and validating error message is displayed
+  const filepathNsfw = 'images/negative-create-account-test.png'
+  cy.accountCreationAddImage(filepathNsfw)
+  cy.get('.red', { timeout: 10000 }).should(
+    'have.text',
+    'Unable to upload file/s due to NSFW status',
+  )
+  //Now adding a non-NSFW image and validating user can pass to next step
+  const filepath = 'images/negative-create-account-test.png'
+  cy.accountCreationAddImage(filepathCorrect)
+  cy.contains('Crop', { timeout: 10000 }).click()
+  cy.get('.red').should('not.exist')
   cy.get('[data-cy=sign-in-button]').click()
   cy.contains('Linking Satellites...')
 })

--- a/integration/create-account.js
+++ b/integration/create-account.js
@@ -55,22 +55,12 @@ it('Create Account', () => {
   cy.get('[data-cy=status-input]').type(randomStatus)
   cy.get('.is-outlined > #custom-cursor-area').click()
   cy.get('.input-file').attachFile(filepathCorrect)
-  cy.contains('Crop').click()
+  cy.contains('Crop', { timeout: 20000 }).click()
   cy.get('[data-cy=sign-in-button]').click()
   cy.contains('Linking Satellites...')
 })
 
 it('Create account with non-NSFW after attempting to load a NSFW image', () => {
-  /*
-  user signs up
-  goes to the sign up add image section
-  adds a NSFW image
-  returns error
-  uploads a non-NSFW image
-  works fine
-  user is able to sign up 
-  assert user was able to sign up
-  */
   //Creating pin, clicking on buttons to continue to user data screen
   cy.accountCreationFirstSteps()
   //Adding random data in user input fields

--- a/support/commands.js
+++ b/support/commands.js
@@ -27,6 +27,8 @@ for (const command of [
   })
 }
 
+//Create account commands
+
 Cypress.Commands.add('createAccount', () => {
   cy.visit('/')
   cy.get('[data-cy=add-input]').type('test001', { log: false })
@@ -48,6 +50,28 @@ Cypress.Commands.add('createAccount', () => {
   cy.get('[data-cy=status-input]').type(randomStatus)
   cy.get('[data-cy=sign-in-button]').click()
 })
+
+Cypress.Commands.add('accountCreationFirstSteps', () => {
+  cy.visit('/')
+  cy.get('[data-cy=add-input]').type('test001', { log: false })
+  cy.get('[data-cy=submit-input]').click()
+  cy.get('.is-primary > #custom-cursor-area').click()
+  cy.contains('Continue').click()
+  cy.contains('I Saved It').click()
+  Cypress.on('uncaught:exception', (err, runnable) => false) // temporary until AP-48 gets fixed
+})
+
+Cypress.Commands.add('accountCreationFillRandomData', () => {
+  cy.get('[data-cy=username-input]').type(randomName)
+  cy.get('[data-cy=status-input]').type(randomStatus)
+})
+
+Cypress.Commands.add('accountCreationAddImage', (filepath) => {
+  cy.get('.is-outlined > #custom-cursor-area').click()
+  cy.get('.input-file').attachFile(filepath)
+})
+
+//Import account commands
 
 Cypress.Commands.add('importAccount', () => {
   cy.visit('/')


### PR DESCRIPTION
**What this PR does** 📖
Adding a new positive test in account creation to validate that user can sign up after attempting to add a NSFW image and then adding a valid picture
Created new cypress commands for common steps during account creation process
Modified create-account.js file to use the new cypress commands implemented
Modified create-account-negative-tests.js file to use the new cypress commands implemented

**Which issue(s) this PR fixes** 🔨
AP-805

**Special notes for reviewers** 🗒️

**Additional comments** 🎤

**Cypress Video** 📺

https://user-images.githubusercontent.com/35935591/154552670-ae680ef4-358d-484c-9c79-72ac174861a2.mp4
https://user-images.githubusercontent.com/35935591/154552705-8acc6fbd-9f90-45d2-8cc3-c40a4a5e0999.mp4


