### PR TITLE
test(cypress): test successful sign up after trying using NSFW

### DIFF
--- a/integration/create-account.js
+++ b/integration/create-account.js
@@ -68,7 +68,7 @@ it('Create account with non-NSFW after attempting to load a NSFW image', () => {
   //Attempting to add NSFW image and validating error message is displayed
   const filepathNsfw = 'images/negative-create-account-test.png'
   cy.accountCreationAddImage(filepathNsfw)
-  cy.get('.red', { timeout: 10000 }).should(
+  cy.get('.red', { timeout: 30000 }).should(
     'have.text',
     'Unable to upload file/s due to NSFW status',
   )
@@ -79,4 +79,25 @@ it('Create account with non-NSFW after attempting to load a NSFW image', () => {
   cy.get('.red').should('not.exist')
   cy.get('[data-cy=sign-in-button]').click()
   cy.contains('Linking Satellites...')
+})
+
+it('Create account successfully without image after attempting to add a NSFW picture', () => {
+  //Creating pin, clicking on buttons to continue to user data screen
+  cy.accountCreationFirstSteps()
+  //Adding random data in user input fields
+  cy.accountCreationFillRandomData()
+  //Attempting to add NSFW image and validating error message is displayed
+  const filepathNsfw = 'images/negative-create-account-test.png'
+  cy.accountCreationAddImage(filepathNsfw)
+  cy.get('.red', { timeout: 30000 }).should(
+    'have.text',
+    'Unable to upload file/s due to NSFW status',
+  )
+  //User is still able to sign in and NSFW image will not be loaded
+  cy.get('[data-cy=sign-in-button]').click()
+  cy.contains('Linking Satellites...')
+  //Validating profile picture is null and default satellite circle is displayed
+  cy.get('.user-state > .is-rounded > .satellite-circle', {
+    timeout: 40000,
+  }).should('exist')
 })

--- a/integration/create-account.js
+++ b/integration/create-account.js
@@ -2,6 +2,7 @@ const faker = require('faker')
 const randomName = faker.internet.userName(name) // generate random name
 const randomStatus = faker.lorem.word() // generate random status
 const filepathCorrect = 'images/logo.png'
+const filepathNsfw = 'images/negative-create-account-test.png'
 
 it('Create Account', () => {
   cy.visit('/')
@@ -66,14 +67,12 @@ it('Create account with non-NSFW after attempting to load a NSFW image', () => {
   //Adding random data in user input fields
   cy.accountCreationFillRandomData()
   //Attempting to add NSFW image and validating error message is displayed
-  const filepathNsfw = 'images/negative-create-account-test.png'
   cy.accountCreationAddImage(filepathNsfw)
   cy.get('.red', { timeout: 30000 }).should(
     'have.text',
     'Unable to upload file/s due to NSFW status',
   )
   //Now adding a non-NSFW image and validating user can pass to next step
-  const filepath = 'images/negative-create-account-test.png'
   cy.accountCreationAddImage(filepathCorrect)
   cy.contains('Crop', { timeout: 10000 }).click()
   cy.get('.red').should('not.exist')
@@ -87,7 +86,6 @@ it('Create account successfully without image after attempting to add a NSFW pic
   //Adding random data in user input fields
   cy.accountCreationFillRandomData()
   //Attempting to add NSFW image and validating error message is displayed
-  const filepathNsfw = 'images/negative-create-account-test.png'
   cy.accountCreationAddImage(filepathNsfw)
   cy.get('.red', { timeout: 30000 }).should(
     'have.text',


### PR DESCRIPTION
after attempting to add nsfw picture

**What this PR does** 📖
Adding a test scenario in create-account.js to validate that user can proceed to signup after attempting to add NSFW image and no picture will be loaded
Increasing timeout to wait for .red element to be displayed on second test to avoid failure in execution
Removed useless const declarations in code

**Which issue(s) this PR fixes** 🔨
AP-806

**Special notes for reviewers** 🗒️

**Additional comments** 🎤

**Cypress Video** 📺

https://user-images.githubusercontent.com/35935591/154573228-51534557-0b69-4483-a86d-d32ceb7a1334.mp4



