### PR TITLE
test(cypress): add tests on mobile browser using cy.viewport()

### DIFF
--- a/fixtures/mobile-devices.json
+++ b/fixtures/mobile-devices.json
@@ -1,0 +1,66 @@
+{
+  "data": {
+    "allDevices": [
+      {
+        "id": 1,
+        "description": "One Plus 10 Pro and One Plus 9",
+        "width": 412,
+        "height": 919
+      },
+      {
+        "id": 2,
+        "description": "Iphone 13 Pro Max and Iphone 12 Pro Max",
+        "width": 428,
+        "height": 926
+      },
+      {
+        "id": 3,
+        "description": "Iphone 13 Mini",
+        "width": 360,
+        "height": 780
+      },
+      {
+        "id": 4,
+        "description": "Iphone 13 Pro and Iphone 13",
+        "width": 390,
+        "height": 844
+      },
+      {
+        "id": 5,
+        "description": "One Plus Nord 2",
+        "width": 412,
+        "height": 915
+      },
+      {
+        "id": 6,
+        "description": "Samsung Galaxy S21",
+        "width": 384,
+        "height": 854
+      },
+      {
+        "id": 7,
+        "description": "Pixel 5 and Xiaomi 10",
+        "width": 393,
+        "height": 851
+      },
+      {
+        "id": 8,
+        "description": "Samsung Galaxy Z Fold2",
+        "width": 884,
+        "height": 1104
+      },
+      {
+        "id": 9,
+        "description": "Ipad Air",
+        "width": 820,
+        "height": 1180
+      },
+      {
+        "id": 10,
+        "description": "Iphone SE 2020",
+        "width": 375,
+        "height": 667
+      }
+    ]
+  }
+}

--- a/integration/chat-features.js
+++ b/integration/chat-features.js
@@ -1,25 +1,20 @@
 const faker = require('faker')
-const randomWord = faker.lorem.word() // generate random word
 const randomNumber = faker.datatype.number() // generate random number
 const randomMessage = faker.lorem.sentence() // generate random sentence
-const textToPaste = 'copy paste stuff'
 
 it('Chat - Send stuff on chat', () => {
   cy.importAccount()
-  cy.contains('aaaaa', { timeout: 60000 }).should('be.visible')
-  cy.contains('aaaaa').click() // clicks on user name
-  cy.get('.messageuser').type(randomMessage)
-  cy.get('.messageuser').type('{enter}') // sending text message
-  cy.contains(randomMessage)
-  cy.get('#emoji-toggle > .control-icon').click()
-  cy.get('[title="smile"]').click() // sending emoji
-  cy.get('.messageuser').click()
-  cy.get('.messageuser').type('{enter}')
-  cy.contains('😄')
-  cy.contains(randomMessage).rightclick()
-  cy.contains('Edit Message').click()
-  cy.get('.edit-message-body-input > p').click()
-  cy.get('.edit-message-body-input > p').type(randomNumber) // editing message
-  cy.get('.edit-message-body-input > p').type('{enter}')
-  cy.contains(randomNumber)
+
+  //Validate profile name displayed
+  cy.chatFeaturesProfileName('asdad')
+
+  // Click on hamburger menu if width < height
+  cy.get('.toggle-sidebar').should('be.visible').click()
+
+  //Validate message and emojis are sent
+  cy.chatFeaturesSendMessage(randomMessage)
+  cy.chatFeaturesSendEmoji('[title="smile"]', '😄')
+
+  //Validate message can be edited
+  cy.chatFeaturesEditMessage(randomMessage, randomNumber)
 })

--- a/integration/create-account-negative-tests.js
+++ b/integration/create-account-negative-tests.js
@@ -4,30 +4,52 @@ const randomStatus = faker.lorem.word() // generate random status
 
 it('Try to create account with PIN less than 5 digits', () => {
   cy.visit('/')
-  cy.contains('Create Account Pin')
-  cy.get('[data-cy=add-input]').type('1')
-  cy.get('[data-cy=submit-input]').click()
-  cy.contains('Pin must be at least 5 characters.')
-  cy.reload()
-  cy.get('[data-cy=submit-input]').click()
+  //Enter PIN screen and add an invalid pin
+  cy.createAccountPINscreen('1')
+
+  //Error message will be displayed
   cy.contains('Pin must be at least 5 characters.')
 })
 
 it('Try to create account without username', () => {
-  //Creating pin, clicking on buttons to continue to user data screen
-  cy.accountCreationFirstSteps()
+  //Enter PIN screen
+  cy.visit('/')
+  cy.createAccountPINscreen('test001')
+
+  //Create or Import account selection screen
+  cy.createAccountSecondScreen()
+
+  //Privacy Settings screen
+  cy.createAccountPrivacyToggles()
+
+  //Recovery Seed Screen
+  cy.createAccountRecoverySeed()
+
+  //Clicking without adding a username will throw an error message
   cy.get('[data-cy=sign-in-button]').click()
   cy.contains('Username must be at least 5 characters.')
 })
 
 it('Try to create account with NSFW image', () => {
-  //Creating pin, clicking on buttons to continue to user data screen
-  cy.accountCreationFirstSteps()
-  //Adding random data in user input fields
-  cy.accountCreationFillRandomData()
+  cy.visit('/')
+  //Enter PIN screen
+  cy.createAccountPINscreen('test001')
+
+  //Create or Import account selection screen
+  cy.createAccountSecondScreen()
+
+  //Privacy Settings screen
+  cy.createAccountPrivacyToggles()
+
+  //Recovery Seed Screen
+  cy.createAccountRecoverySeed()
+
+  //Username and Status Input
+  cy.createAccountUserInput(randomName, randomStatus)
+
   //Attempting to add NSFW image and validating error message is displayed
-  const filepath = 'images/negative-create-account-test.png'
-  cy.accountCreationAddImage(filepath)
+  const filepathNsfw = 'images/negative-create-account-test.png'
+  cy.createAccountAddImage(filepathNsfw)
   cy.get('.red', { timeout: 10000 }).should(
     'have.text',
     'Unable to upload file/s due to NSFW status',

--- a/integration/create-account.js
+++ b/integration/create-account.js
@@ -6,94 +6,77 @@ const filepathNsfw = 'images/negative-create-account-test.png'
 
 it('Create Account', () => {
   cy.visit('/')
-  cy.url().should('contains', '/#/auth/unlock')
-  cy.contains('Create Account Pin')
-  cy.contains("The pin can be anything you want, just don't forget it.")
-  cy.contains('Choose Your Pin')
-  cy.get('[data-cy=add-input]').type('test001', { log: false })
-  cy.contains('Store Pin? (Less Secure)')
-  cy.get('[data-cy=submit-input]').click()
-  cy.contains(
-    "We're going to create an account for you. On the next screen, you'll see a set of words. Screenshot this or write it down. This is the only way to backup your account.",
-  )
-  cy.get('.is-primary > #custom-cursor-area').click()
-  cy.contains('Privacy Settings')
-  cy.contains(
-    'Choose which features to enable to best suit your privacy preferences.',
-  )
-  cy.contains('Register Username Publicly')
-  cy.contains(
-    'Publicly associate your account ID with a human readable username. Anyone can see this association.',
-  )
-  cy.contains(
-    "Store your account pin locally so you don't have to enter it manually every time. This is not recommended.",
-  )
-  cy.contains('Display Current Activity')
-  cy.contains(
-    "Allow Satellite to see what games you're playing and show them off on your profile so friends can jump in.",
-  )
-  cy.contains('Enable External Embeds')
-  cy.contains(
-    'Allow Satellite to fetch data from external sites in order to expand links like Spotify, YouTube, and more.',
-  )
-  cy.get('.switch-button').each(($btn, index, $List) => {
-    if ($btn.hasClass('enabled')) {
-      cy.wrap($btn).click().should('not.have.class', 'enabled')
-    } else {
-      cy.wrap($btn).click().should('have.class', 'enabled')
-    }
-  })
-  cy.get('#custom-cursor-area').click()
-  cy.get('.title').should('contain', 'Recovery Seed')
-  cy.get('#custom-cursor-area').click()
-  cy.contains('Customize how the world sees you, choose something memorable.', {
-    timeout: 10000,
-  }).should('be.visible')
-  cy.contains('Username')
-  Cypress.on('uncaught:exception', (err, runnable) => false) // temporary until AP-48 gets fixed
-  cy.get('[data-cy=username-input]').type(randomName)
-  cy.contains('Status')
-  cy.get('[data-cy=status-input]').type(randomStatus)
-  cy.get('.is-outlined > #custom-cursor-area').click()
-  cy.get('.input-file').attachFile(filepathCorrect)
-  cy.contains('Crop', { timeout: 20000 }).click()
-  cy.get('[data-cy=sign-in-button]').click()
-  cy.contains('Linking Satellites...')
+  //Enter PIN screen
+  cy.createAccountPINscreen('test001')
+
+  //Create or Import account selection screen
+  cy.createAccountSecondScreen()
+
+  //Privacy Settings screen
+  cy.createAccountPrivacyToggles()
+
+  //Recovery Seed Screen
+  cy.createAccountRecoverySeed()
+
+  //Username and Status Input
+  cy.createAccountUserInput(randomName, randomStatus)
+
+  //User Image Input
+  cy.createAccountAddImage(filepathCorrect)
+  cy.contains('Crop', { timeout: 20000 }).should('be.visible').click()
+
+  //Finishing Account Creation
+  cy.createAccountSubmit()
 })
 
 it('Create account with non-NSFW after attempting to load a NSFW image', () => {
+  cy.visit('/')
   //Creating pin, clicking on buttons to continue to user data screen
-  cy.accountCreationFirstSteps()
+  cy.createAccountPINscreen('test001')
+  cy.createAccountSecondScreen()
+  cy.createAccountPrivacyToggles()
+  cy.createAccountRecoverySeed()
+
   //Adding random data in user input fields
-  cy.accountCreationFillRandomData()
+  cy.createAccountUserInput(randomName, randomStatus)
+
   //Attempting to add NSFW image and validating error message is displayed
-  cy.accountCreationAddImage(filepathNsfw)
+  cy.createAccountAddImage(filepathNsfw)
   cy.get('.red', { timeout: 30000 }).should(
     'have.text',
     'Unable to upload file/s due to NSFW status',
   )
+
   //Now adding a non-NSFW image and validating user can pass to next step
-  cy.accountCreationAddImage(filepathCorrect)
+  cy.createAccountAddImage(filepathCorrect)
   cy.contains('Crop', { timeout: 10000 }).click()
   cy.get('.red').should('not.exist')
-  cy.get('[data-cy=sign-in-button]').click()
-  cy.contains('Linking Satellites...')
+
+  //Finishing Account Creation
+  cy.createAccountSubmit()
 })
 
 it('Create account successfully without image after attempting to add a NSFW picture', () => {
+  cy.visit('/')
   //Creating pin, clicking on buttons to continue to user data screen
-  cy.accountCreationFirstSteps()
+  cy.createAccountPINscreen('test001')
+  cy.createAccountSecondScreen()
+  cy.createAccountPrivacyToggles()
+  cy.createAccountRecoverySeed()
+
   //Adding random data in user input fields
-  cy.accountCreationFillRandomData()
+  cy.createAccountUserInput(randomName, randomStatus)
+
   //Attempting to add NSFW image and validating error message is displayed
-  cy.accountCreationAddImage(filepathNsfw)
+  cy.createAccountAddImage(filepathNsfw)
   cy.get('.red', { timeout: 30000 }).should(
     'have.text',
     'Unable to upload file/s due to NSFW status',
   )
+
   //User is still able to sign in and NSFW image will not be loaded
-  cy.get('[data-cy=sign-in-button]').click()
-  cy.contains('Linking Satellites...')
+  cy.createAccountSubmit()
+
   //Validating profile picture is null and default satellite circle is displayed
   cy.get('.user-state > .is-rounded > .satellite-circle', {
     timeout: 40000,

--- a/integration/mobiles-responsiveness.js
+++ b/integration/mobiles-responsiveness.js
@@ -1,0 +1,69 @@
+import { data } from '../fixtures/mobile-devices.json'
+
+const faker = require('faker')
+const randomName = faker.internet.userName(name) // generate random name
+const randomStatus = faker.lorem.word() // generate random status
+const filepathCorrect = 'images/logo.png'
+const randomNumber = faker.datatype.number() // generate random number
+const randomMessage = faker.lorem.sentence() // generate random sentence
+
+describe('Run responsiveness tests on several devices', () => {
+  data.allDevices.forEach((item) => {
+    it(`Create Account on ${item.description}`, () => {
+      //Visiting main page and changing viewport
+      cy.visit('/')
+      cy.viewport(item.width, item.height)
+
+      //Enter PIN screen
+      cy.createAccountPINscreen('test001')
+
+      //Create or Import account selection screen
+      cy.createAccountSecondScreen()
+
+      //Privacy Settings screen
+      cy.createAccountPrivacyToggles()
+
+      //Recovery Seed Screen
+      cy.createAccountRecoverySeed()
+
+      //Username and Status Input
+      cy.createAccountUserInput(randomName, randomStatus)
+
+      //User Image Input
+      cy.createAccountAddImage(filepathCorrect)
+      cy.contains('Crop', { timeout: 20000 }).should('be.visible').click()
+
+      //Finishing Account Creation
+      cy.createAccountSubmit()
+    })
+
+    it(`Import Account on ${item.description}`, () => {
+      cy.viewport(item.width, item.height)
+      cy.importAccount()
+    })
+
+    it(`Chat Features on ${item.description}`, () => {
+      //Setting viewport
+      cy.viewport(item.width, item.height)
+
+      //Validate profile name displayed
+      cy.chatFeaturesProfileName('asdad')
+
+      // Click on hamburger menu if width < height
+      cy.get('.toggle-sidebar').should('be.visible').click()
+
+      //Validate message and emojis are sent
+      cy.chatFeaturesSendMessage(randomMessage)
+      cy.chatFeaturesSendEmoji('[title="smile"]', '😄')
+
+      //Validate message can be edited
+      cy.chatFeaturesEditMessage(randomMessage, randomNumber)
+    })
+
+    it(`Release Notes Screen on ${item.description}`, () => {
+      cy.viewport(item.width, item.height)
+      cy.visit('/')
+      cy.releaseNotesScreenValidation()
+    })
+  })
+})

--- a/integration/privacy-page-toggles.js
+++ b/integration/privacy-page-toggles.js
@@ -8,9 +8,11 @@ let toggleStatusProfile = []
 before(() => {
   //Adding pin to continue to toggles switches screen
   cy.visit('/')
-  cy.get('[data-cy=add-input]').type('test001', { log: false })
-  cy.get('[data-cy=submit-input]').click()
-  cy.get('.is-primary > #custom-cursor-area').click()
+  //Enter PIN screen
+  cy.createAccountPINscreen('test001')
+
+  //Create or Import account selection screen
+  cy.createAccountSecondScreen()
 })
 
 /* Commenting code below because tests will fail due to bug AP-795 
@@ -53,15 +55,15 @@ it('Privacy page - Verify all toggles switches work as should', () => {
 it('Privacy page - Verify user can still proceed after adjusting switches', () => {
   //Going to Recovery Seed screen and clicking on button to go to next screen
   cy.get('#custom-cursor-area').click()
-  cy.get('.title').should('contain', 'Recovery Seed')
-  cy.contains('I Saved It').click()
-  Cypress.on('uncaught:exception', (err, runnable) => false) // temporary until AP-48 gets fixed
-  //Adding random data for user inputs and click on button to continue
-  cy.get('[data-cy=username-input]').type(randomName)
-  cy.get('[data-cy=status-input]').type(randomStatus)
-  cy.get('[data-cy=sign-in-button]').click()
-  //Validating buffering screen text and that user is redirected to friends/list
-  cy.contains('Linking Satellites...')
+
+  //Recovery Seed Screen
+  cy.createAccountRecoverySeed()
+
+  //Username and Status Input
+  cy.createAccountUserInput(randomName, randomStatus)
+
+  //Click on button, validate buffering screen and that user is redirected to friends/list
+  cy.createAccountSubmit()
   cy.url({ timeout: 30000 }).should('contain', 'friends/list')
 })
 

--- a/integration/version-release-notes.js
+++ b/integration/version-release-notes.js
@@ -1,7 +1,4 @@
 it('Release notes appear when clicking on version number', () => {
   cy.visit('/')
-  cy.get('[data-cy=version]').click()
-  cy.contains('Update')
-  cy.contains('is Here!')
-  cy.contains('Got It!').click()
+  cy.releaseNotesScreenValidation()
 })

--- a/support/commands.js
+++ b/support/commands.js
@@ -27,7 +27,7 @@ for (const command of [
   })
 }
 
-//Create account commands
+//Create Account Commands
 
 Cypress.Commands.add('createAccount', () => {
   cy.visit('/')
@@ -51,41 +51,143 @@ Cypress.Commands.add('createAccount', () => {
   cy.get('[data-cy=sign-in-button]').click()
 })
 
-Cypress.Commands.add('accountCreationFirstSteps', () => {
-  cy.visit('/')
-  cy.get('[data-cy=add-input]').type('test001', { log: false })
-  cy.get('[data-cy=submit-input]').click()
-  cy.get('.is-primary > #custom-cursor-area').click()
-  cy.contains('Continue').click()
-  cy.contains('I Saved It').click()
+Cypress.Commands.add('createAccountPINscreen', (pin) => {
+  cy.url().should('contains', '/#/auth/unlock')
+  cy.contains('Create Account Pin').should('be.visible')
+  cy.contains("The pin can be anything you want, just don't forget it.").should(
+    'be.visible',
+  )
+  cy.contains('Choose Your Pin').should('be.visible')
+  cy.get('[data-cy=add-input]').should('be.visible').type(pin, { log: false })
+  cy.contains('Store Pin? (Less Secure)').should('be.visible')
+  cy.get('[data-cy=submit-input]').should('be.visible').click()
+})
+
+Cypress.Commands.add('createAccountSecondScreen', () => {
+  cy.contains(
+    "We're going to create an account for you. On the next screen, you'll see a set of words. Screenshot this or write it down. This is the only way to backup your account.",
+  ).should('be.visible')
+  cy.get('.is-primary > #custom-cursor-area').should('be.visible').click()
+})
+
+Cypress.Commands.add('createAccountPrivacyToggles', () => {
+  cy.contains('Privacy Settings').should('be.visible')
+  cy.contains(
+    'Choose which features to enable to best suit your privacy preferences.',
+  ).should('be.visible')
+  cy.contains('Register Username Publicly').should('be.visible')
+  cy.contains(
+    'Publicly associate your account ID with a human readable username. Anyone can see this association.',
+  ).should('be.visible')
+  cy.contains(
+    "Store your account pin locally so you don't have to enter it manually every time. This is not recommended.",
+  ).should('be.visible')
+  cy.contains('Display Current Activity').should('be.visible')
+  cy.contains(
+    "Allow Satellite to see what games you're playing and show them off on your profile so friends can jump in.",
+  ).should('be.visible')
+  cy.contains('Enable External Embeds').should('be.visible')
+  cy.contains(
+    'Allow Satellite to fetch data from external sites in order to expand links like Spotify, YouTube, and more.',
+  ).should('be.visible')
+  cy.get('.switch-button')
+    .should('be.visible')
+    .each(($btn, index, $List) => {
+      if ($btn.hasClass('enabled')) {
+        cy.wrap($btn).click().should('not.have.class', 'enabled')
+      } else {
+        cy.wrap($btn).click().should('have.class', 'enabled')
+      }
+    })
+  cy.get('#custom-cursor-area').should('be.visible').click()
+})
+
+Cypress.Commands.add('createAccountRecoverySeed', () => {
+  cy.get('.title').should('be.visible').should('contain', 'Recovery Seed')
+  cy.contains('I Saved It').should('be.visible')
+  cy.get('#custom-cursor-area').should('be.visible').click()
   Cypress.on('uncaught:exception', (err, runnable) => false) // temporary until AP-48 gets fixed
 })
 
-Cypress.Commands.add('accountCreationFillRandomData', () => {
-  cy.get('[data-cy=username-input]').type(randomName)
-  cy.get('[data-cy=status-input]').type(randomStatus)
+Cypress.Commands.add('createAccountUserInput', (username, status) => {
+  cy.contains('Customize how the world sees you, choose something memorable.', {
+    timeout: 10000,
+  }).should('be.visible')
+  cy.get('[data-cy=username-input]').should('be.visible').type(randomName)
+  cy.get('[data-cy=status-input]').should('be.visible').type(randomStatus)
 })
 
-Cypress.Commands.add('accountCreationAddImage', (filepath) => {
-  cy.get('.is-outlined > #custom-cursor-area').click()
+Cypress.Commands.add('createAccountAddImage', (filepath) => {
+  cy.get('.is-outlined > #custom-cursor-area').should('be.visible').click()
   cy.get('.input-file').attachFile(filepath)
 })
 
-//Import account commands
+Cypress.Commands.add('createAccountSubmit', () => {
+  cy.get('[data-cy=sign-in-button]').should('be.visible').click()
+  cy.contains('Linking Satellites...').should('be.visible')
+})
+
+//Import Account Commands
 
 Cypress.Commands.add('importAccount', () => {
   cy.visit('/')
-  cy.get('[data-cy=add-input]').type('test001', { log: false })
-  cy.get('[data-cy=submit-input]').click()
-  cy.contains('Import Account').click()
+  cy.get('[data-cy=add-input]')
+    .should('be.visible')
+    .type('test001', { log: false })
+  cy.get('[data-cy=submit-input]').should('be.visible').click()
+  cy.contains('Import Account').should('be.visible').click()
   cy.contains(
     'Enter your 12 word passphrase in exactly the same order your recovery seed was generated.',
-  )
-  cy.get('[data-cy=add-passphrase]').type(
-    'boring over tilt regret diamond rubber example there fire roof sheriff always',
-    { log: false },
-  )
+  ).should('be.visible')
+  cy.get('[data-cy=add-passphrase]')
+    .should('be.visible')
+    .type(
+      'boring over tilt regret diamond rubber example there fire roof sheriff always',
+      { log: false },
+    )
   cy.get('[data-cy=add-passphrase]').type('{enter}')
-  cy.contains('Recover Account').click()
+  cy.contains('Recover Account').should('be.visible').click()
   Cypress.on('uncaught:exception', (err, runnable) => false) // temporary until AP-48 gets fixed
+})
+
+//Chat Features Commands
+
+Cypress.Commands.add('chatFeaturesProfileName', (value) => {
+  cy.contains(value, { timeout: 60000 }).should('be.visible')
+  cy.contains(value).click() // clicks on user name
+})
+
+Cypress.Commands.add('chatFeaturesSendMessage', (message) => {
+  cy.get('.messageuser').type(message)
+  cy.get('.messageuser').type('{enter}') // sending text message
+  cy.contains(message)
+})
+
+Cypress.Commands.add('chatFeaturesSendEmoji', (emojiLocator, emojiValue) => {
+  cy.get('#emoji-toggle > .control-icon').click()
+  cy.get(emojiLocator).click() // sending emoji
+  cy.get('.messageuser').click()
+  cy.get('.messageuser').type('{enter}')
+  cy.contains(emojiValue)
+})
+
+Cypress.Commands.add(
+  'chatFeaturesEditMessage',
+  (messageToEdit, messageEdited) => {
+    cy.contains(messageToEdit).rightclick()
+    cy.contains('Edit Message').click()
+    cy.get('.edit-message-body-input').click()
+    cy.get('.edit-message-body-input').type(messageEdited) // editing message
+    cy.get('.edit-message-body-input').type('{enter}')
+    cy.contains(messageEdited)
+  },
+)
+
+//Version Release Notes Commands
+
+Cypress.Commands.add('releaseNotesScreenValidation', () => {
+  cy.get('[data-cy=version]').should('be.visible').click()
+  cy.contains('Update').should('be.visible')
+  cy.contains('is Here!').should('be.visible')
+  cy.contains('Got It!').should('be.visible').click()
 })


### PR DESCRIPTION
**What this PR does** 📖
Adds a new test file mobiles-responsiveness.js to include tests for the basic flows of the application executed in different viewports
Adds a mobile-devices.json fixture file that includes the setup of the viewports requested to be validated
Adds cypress commands for common steps in account creation, chat features and release notes
Implements the usage of the new cypress commands inside the existing tests

**Which issue(s) this PR fixes** 🔨
AP-715

**Special notes for reviewers** 🗒️
The following issues were presented during execution:
1. User Input Data screen displays a scroll bar not needed on the following viewports:
    1. One Plus 10 Pro/One Plus 9
    2. Iphone 13 Pro Max 12 Pro Max
    3. Iphone 13 Mini
    4. Iphone 13 Pro and 13
    5. One Plus Nord 2
    6. Samsung Galaxy S21
    7. Pixel 5 and Xiaomi 10
    8. Iphone SE 2020
2. For the same viewports listed above, on Chat Screen, the menu from the top with the Search Bar is not displayed complete
3. When you click on Release Notes for a moment it is displayed “Update Undefined” before loading the actual Release Notes/App Version

![image](https://user-images.githubusercontent.com/35935591/154998941-36f67be6-a942-4c34-8302-af95b034699a.png)

4. Error: Failed to get balance of account (uncaught exception) error is triggered during Account Creation process (Linking Satellites... screen). This issue is just displayed in the cypress log and does not crash the application
5. (Uncaught exception( TypeError: this._agent.destroy) is displayed while importing an account on linking satellites screen. This issue is just displayed in the cypress log and does not crash the application

**Additional comments** 🎤

**Cypress Video** 📺

https://user-images.githubusercontent.com/35935591/154998999-b111ad49-c11f-4e6d-8a67-51e78de92d33.mp4


