### PR TITLE
test(cypress): add snapshot testing for create import account flows

### DIFF
--- a/integration/snapshots-test.js
+++ b/integration/snapshots-test.js
@@ -1,0 +1,147 @@
+const faker = require('faker')
+const randomName = faker.internet.userName(name) // generate random name
+const randomStatus = faker.lorem.word() // generate random status
+const recoverySeed =
+  'diet acquire phone casino sister scatter news notable sustain lift mercy right'
+
+describe('Snapshots Testing', () => {
+  it('Import account', () => {
+    //Import account and snapshot on each screen
+    //Enter PIN Screen
+    cy.visit('/')
+    cy.viewport(1400, 1000)
+    cy.snapshotTestGet('.subtitle', 'Create Account Pin')
+    cy.get('[data-cy=add-input]')
+      .should('be.visible')
+      .type('test001', { log: false })
+    cy.get('[data-cy=submit-input]').should('be.visible').click()
+
+    //Create or Import Account Selection Screen
+    cy.snapshotTestContains('Import Account')
+    cy.contains('Import Account').click()
+
+    //Enter the passphrase screen
+    cy.snapshotTestContains(
+      'Enter your 12 word passphrase in exactly the same order your recovery seed was generated.',
+    )
+    cy.get('[data-cy=add-passphrase]')
+      .should('be.visible')
+      .type(recoverySeed, { log: false })
+    cy.get('[data-cy=add-passphrase]').type('{enter}')
+
+    //Snapshot after adding recovery seed
+    cy.snapshotTestContains('Recover Account')
+    cy.contains('Recover Account').click()
+    Cypress.on('uncaught:exception', (err, runnable) => false) // temporary until AP-48 gets fixed
+
+    //Snapshots on buffering screen and main screen
+    cy.snapshotTestContains('Linking Satellites...', 20000)
+    cy.snapshotTestContains('SnapQA', 30000)
+
+    // Go to files
+    cy.get('.sidebar-nav > .is-dark > #custom-cursor-area').click()
+    cy.snapshotTestGet('.switcher-container > .is-text', 'Files')
+
+    // Go to friends
+    cy.get(
+      '[style="position: relative;"] > .sidebar-full-btn > #custom-cursor-area',
+    ).click()
+    cy.snapshotTestContains('Add Friend')
+
+    // Go to a chat
+    cy.get('[data-tooltip="Message"]').click()
+    cy.snapshotTestContains('connected', 20000)
+
+    // Click on emojis
+    cy.get('#emoji-toggle').click()
+    cy.snapshotTestGet(
+      '.navbar > .button-group > .active > #custom-cursor-area',
+      'Emoji',
+    )
+
+    // Click on glyphs
+    cy.get('#emoji-toggle').click()
+    cy.get('#glyph-toggle').click()
+    cy.snapshotTestGet('.pack-list > .is-text', 'Try using some glyphs')
+    cy.get('#glyph-toggle').click()
+
+    // Go to each settings option and snapshot each
+    // Go to Settings - General - Personalize
+    cy.get('[data-tooltip="Settings"] > .is-rounded > svg').click()
+    cy.snapshotTestContains('Personalize Satellite')
+
+    // Go to Settings - General - Profile
+    cy.openSettingsMenuOption('Profile')
+    cy.snapshotTestContains('Account Info')
+
+    // Go to Settings - General - Audio & Video
+    cy.openSettingsMenuOption('Audio & Video')
+    cy.snapshotTestContains('Audio Input')
+
+    // Go to Settings - General - Keybinds
+    cy.openSettingsMenuOption('Keybinds')
+    cy.snapshotTestContains('Default Keybinds')
+
+    // Go to Settings - General - Accounts & Devices
+    cy.openSettingsMenuOption('Accounts & Devices')
+    cy.get('.column > .title').should('contain', 'Accounts & Devices')
+    cy.snapshotTestContains('Accounts & Devices')
+
+    // Go to Settings - General - Privacy
+    cy.openSettingsMenuOption('Privacy')
+    cy.snapshotTestContains('Privacy Settings')
+
+    // Go to Settings - Realms & Security - Realms
+    cy.openSettingsMenuOption('Realms')
+    cy.get('.column > .title').should('contain', 'Realms')
+    cy.snapshotTestContains('Realms')
+
+    // Go to Settings - Realms & Security - Storage
+    cy.openSettingsMenuOption('Storage')
+    cy.get('.column > .title').should('contain', 'Storage')
+    cy.snapshotTestContains('Storage')
+
+    // Go to Settings - Realms & Security - Network
+    cy.openSettingsMenuOption('Network')
+    cy.get('.column > .title').should('contain', 'Network')
+    cy.snapshotTestContains('Network')
+
+    // Go to Settings - Developer - Notifications
+    cy.openSettingsMenuOption('Notifications')
+    cy.snapshotTestContains('Notifications Settings')
+
+    // Go to Settings - Developer - App Info
+    cy.openSettingsMenuOption('App Info')
+    cy.snapshotTestContains('Application Info')
+    cy.get('.ps-container > .close-button').click()
+  })
+
+  it('Create account', () => {
+    //Open URL and snapshot
+    cy.visit('/')
+    cy.viewport(1400, 1000)
+    cy.snapshotTestGet('.subtitle', 'Create Account Pin')
+    cy.createAccountPINscreen('test001')
+
+    //Create or Import account selection screen
+    cy.snapshotTestContains('Create Account')
+    cy.createAccountSecondScreen()
+
+    //Privacy Settings screen
+    cy.snapshotTestContains('Privacy Settings')
+    cy.createAccountPrivacyToggles()
+
+    //Recovery Seed Screen then User Input Snapshot
+    cy.createAccountRecoverySeed().then(() => {
+      cy.snapshotTestContains(
+        'Customize how the world sees you, choose something memorable.',
+        30000,
+      )
+    })
+
+    //User input fill and finishing account creation
+    cy.createAccountUserInput(randomName, randomStatus)
+    cy.createAccountSubmit()
+    cy.snapshotTestContains('Linking Satellites...', 20000)
+  })
+})

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "cypress-localstorage-commands": "^1.6.1",
     "cypress-plugin-snapshots": "^1.4.4",
     "husky": "^7.0.0",
-    "netlify-plugin-cypress": "^2.2.0",
     "pretty-quick": "^3.1.3"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "@commitlint/cli": "^16.2.1",
     "@commitlint/config-conventional": "^16.2.1",
     "cypress-localstorage-commands": "^1.6.1",
+    "cypress-plugin-snapshots": "^1.4.4",
     "husky": "^7.0.0",
+    "netlify-plugin-cypress": "^2.2.0",
     "pretty-quick": "^3.1.3"
   },
   "scripts": {

--- a/plugins/index.js
+++ b/plugins/index.js
@@ -1,1 +1,6 @@
-module.exports = (on, config) => {}
+const { initPlugin } = require('cypress-plugin-snapshots/plugin')
+
+module.exports = (on, config) => {
+  initPlugin(on, config)
+  return config
+}

--- a/support/commands.js
+++ b/support/commands.js
@@ -191,3 +191,27 @@ Cypress.Commands.add('releaseNotesScreenValidation', () => {
   cy.contains('is Here!').should('be.visible')
   cy.contains('Got It!').should('be.visible').click()
 })
+
+//Snapshot Testing
+
+Cypress.Commands.add('snapshotTestContains', (text, timeout = 4000) => {
+  cy.contains(text, { timeout: timeout })
+    .should('be.visible')
+    .then(() => {
+      cy.document().toMatchImageSnapshot()
+    })
+})
+
+Cypress.Commands.add('snapshotTestGet', (locator, text, timeout = 4000) => {
+  cy.get(locator, { timeout: timeout })
+    .should('contain', text)
+    .then(() => {
+      cy.document().toMatchImageSnapshot()
+    })
+})
+
+//Settings Menu
+
+Cypress.Commands.add('openSettingsMenuOption', (option) => {
+  cy.get('.menu-list').contains(option).click()
+})

--- a/support/index.js
+++ b/support/index.js
@@ -1,1 +1,2 @@
 import './commands'
+import 'cypress-plugin-snapshots/commands'


### PR DESCRIPTION
**What this PR does** 📖
Adding cypress-plugin-snapshots into Cypress repository to execute the snapshots validations
Adding cypress commands to handle common actions on snapshots validations and for browsing the settings menu options
Adding tests for snapshots on Import Account, Settings, Messages and Create Account screens

**Which issue(s) this PR fixes** 🔨
AP-817

**Special notes for reviewers** 🗒️
An additional change into cypress.json is needed for this plugin but this cannot go inside this pull request since this file is outside of the cypress repository

**Additional comments** 🎤
If you run this test in the cypress runner and then from the CL you will see that the tests fail because apparently Cypress creates the baseline images in different resolutions depending in which way the tests are executed. So, I recommend to remove the baseline screenshots before switching from test runner to CL or backwards.

**Cypress Video** 📺

https://user-images.githubusercontent.com/35935591/155444902-60c6edaa-b22d-48e3-b7dd-a6d60114dd81.mp4


