### PR TITLE
test(cypress): add tests lock and unlock pin

### DIFF
--- a/integration/pin-unlock-validations.js
+++ b/integration/pin-unlock-validations.js
@@ -1,0 +1,94 @@
+const userPassphrase =
+  'boring over tilt regret diamond rubber example there fire roof sheriff always'
+
+describe('Unlock pin should be persisted when store pin is enabled', () => {
+  it('Create Account with store pin disabled', () => {
+    //Go to URL, add a PIN and make sure that toggle for save pin is disabled
+    cy.visit('/')
+    cy.createAccountPINscreen('test001', false)
+
+    //Follow the next steps to create an account
+    cy.createAccountSecondScreen()
+    cy.createAccountPrivacyTogglesGoNext()
+    cy.createAccountRecoverySeed()
+    cy.createAccountUserInput()
+    cy.createAccountSubmit()
+
+    //Wait until main page is loaded after creating account
+    cy.get('.user-state > .is-rounded > .satellite-circle', {
+      timeout: 120000,
+    }).should('be.visible')
+
+    // Go to main URL again and validate that user is prompt to enter pin again
+    cy.visit('/').then(() => {
+      cy.contains('Decrypt Account').should('be.visible')
+    })
+  })
+
+  it('Create Account with store pin enabled', () => {
+    //Go to URL, add a PIN and make sure that toggle for save pin is enabled
+    cy.visit('/')
+    cy.createAccountPINscreen('test002', true)
+
+    //Follow the next steps to create an account
+    cy.createAccountSecondScreen()
+    cy.createAccountPrivacyTogglesGoNext()
+    cy.createAccountRecoverySeed()
+    cy.createAccountUserInput()
+    cy.createAccountSubmit()
+
+    //Wait until main page is loaded after creating account
+    cy.get('.user-state > .is-rounded > .satellite-circle', {
+      timeout: 120000,
+    }).should('be.visible')
+
+    // Go to main URL again and validate that user is redirected to chat screen and pin was saved
+    cy.visit('/').then(() => {
+      cy.get('#status > .user-state > .is-rounded > .satellite-circle', {
+        timeout: 120000,
+      }).should('be.visible')
+    })
+  })
+
+  it('Import Account with store pin disabled', () => {
+    //Go to URL, add a PIN and make sure that toggle for save pin is disabled
+    cy.clearLocalStorage().then(() => {
+      cy.visit('/')
+      cy.importAccountPINscreen('test003', false)
+    })
+
+    //Follow the next steps to import an account
+    cy.importAccountEnterPassphrase(userPassphrase)
+
+    //Wait until main page is loaded after importing account
+    cy.get('.user-state > .is-rounded > .satellite-circle', {
+      timeout: 120000,
+    }).should('be.visible')
+
+    // Go to main URL again and validate that user is prompt to enter pin again
+    cy.visit('/').then(() => {
+      cy.contains('Decrypt Account').should('be.visible')
+    })
+  })
+
+  it('Import Account with store pin enabled', () => {
+    //Go to URL, add a PIN and make sure that toggle for save pin is enabled
+    cy.visit('/')
+    cy.importAccountPINscreen('test004', true)
+
+    //Follow the next steps to import an account
+    cy.importAccountEnterPassphrase(userPassphrase)
+
+    //Wait until main page is loaded after importing account
+    cy.get('.user-state > .is-rounded > .satellite-circle', {
+      timeout: 120000,
+    }).should('be.visible')
+
+    // Go to main URL again and validate that user is redirected to chat screen and pin was saved
+    cy.visit('/').then(() => {
+      cy.get('#status > .user-state > .is-rounded > .satellite-circle', {
+        timeout: 120000,
+      }).should('be.visible')
+    })
+  })
+})

--- a/integration/snapshots-test.js
+++ b/integration/snapshots-test.js
@@ -2,7 +2,7 @@ const faker = require('faker')
 const randomName = faker.internet.userName(name) // generate random name
 const randomStatus = faker.lorem.word() // generate random status
 const recoverySeed =
-  'diet acquire phone casino sister scatter news notable sustain lift mercy right'
+  'black blossom pink damage together artwork coil west clown turn chimney physical'
 
 describe('Snapshots Testing', () => {
   it('Import account', () => {
@@ -35,8 +35,8 @@ describe('Snapshots Testing', () => {
     Cypress.on('uncaught:exception', (err, runnable) => false) // temporary until AP-48 gets fixed
 
     //Snapshots on buffering screen and main screen
-    cy.snapshotTestContains('Linking Satellites...', 20000)
-    cy.snapshotTestContains('SnapQA', 30000)
+    cy.snapshotTestContains('Linking Satellites...', 60000)
+    cy.snapshotTestContains('SnapQA', 60000)
 
     // Go to files
     cy.get('.sidebar-nav > .is-dark > #custom-cursor-area').click()
@@ -72,11 +72,12 @@ describe('Snapshots Testing', () => {
 
     // Go to Settings - General - Profile
     cy.openSettingsMenuOption('Profile')
-    cy.snapshotTestContains('Account Info')
+    cy.get('.title').should('contain', 'Profile')
+    cy.snapshotTestContains('Profile')
 
     // Go to Settings - General - Audio & Video
     cy.openSettingsMenuOption('Audio & Video')
-    cy.snapshotTestContains('Audio Input')
+    cy.snapshotTestContains('Audio Sources')
 
     // Go to Settings - General - Keybinds
     cy.openSettingsMenuOption('Keybinds')
@@ -105,10 +106,6 @@ describe('Snapshots Testing', () => {
     cy.openSettingsMenuOption('Network')
     cy.get('.column > .title').should('contain', 'Network')
     cy.snapshotTestContains('Network')
-
-    // Go to Settings - Developer - Notifications
-    cy.openSettingsMenuOption('Notifications')
-    cy.snapshotTestContains('Notifications Settings')
 
     // Go to Settings - Developer - App Info
     cy.openSettingsMenuOption('App Info')

--- a/plugins/index.js
+++ b/plugins/index.js
@@ -1,6 +1,12 @@
 const { initPlugin } = require('cypress-plugin-snapshots/plugin')
 
 module.exports = (on, config) => {
+  on('before:browser:launch', (browser, launchOptions) => {
+    if (browser.name === 'chrome' && browser.isHeadless) {
+      launchOptions.args.push('--disable-gpu')
+      return launchOptions
+    }
+  })
   initPlugin(on, config)
   return config
 }

--- a/support/commands.js
+++ b/support/commands.js
@@ -51,7 +51,7 @@ Cypress.Commands.add('createAccount', () => {
   cy.get('[data-cy=sign-in-button]').click()
 })
 
-Cypress.Commands.add('createAccountPINscreen', (pin) => {
+Cypress.Commands.add('createAccountPINscreen', (pin, savePin = false) => {
   cy.url().should('contains', '/#/auth/unlock')
   cy.contains('Create Account Pin').should('be.visible')
   cy.contains("The pin can be anything you want, just don't forget it.").should(
@@ -60,6 +60,11 @@ Cypress.Commands.add('createAccountPINscreen', (pin) => {
   cy.contains('Choose Your Pin').should('be.visible')
   cy.get('[data-cy=add-input]').should('be.visible').type(pin, { log: false })
   cy.contains('Store Pin? (Less Secure)').should('be.visible')
+  if (savePin === true) {
+    cy.get('.switch-button').click().should('have.class', 'enabled')
+  } else {
+    cy.get('.switch-button').should('not.have.class', 'enabled')
+  }
   cy.get('[data-cy=submit-input]').should('be.visible').click()
 })
 
@@ -99,6 +104,11 @@ Cypress.Commands.add('createAccountPrivacyToggles', () => {
         cy.wrap($btn).click().should('have.class', 'enabled')
       }
     })
+  cy.get('#custom-cursor-area').should('be.visible').click()
+})
+
+Cypress.Commands.add('createAccountPrivacyTogglesGoNext', () => {
+  cy.contains('Privacy Settings').should('be.visible')
   cy.get('#custom-cursor-area').should('be.visible').click()
 })
 
@@ -145,6 +155,29 @@ Cypress.Commands.add('importAccount', () => {
       'boring over tilt regret diamond rubber example there fire roof sheriff always',
       { log: false },
     )
+  cy.get('[data-cy=add-passphrase]').type('{enter}')
+  cy.contains('Recover Account').should('be.visible').click()
+  Cypress.on('uncaught:exception', (err, runnable) => false) // temporary until AP-48 gets fixed
+})
+
+Cypress.Commands.add('importAccountPINscreen', (pin, savePin = false) => {
+  cy.get('[data-cy=add-input]').should('be.visible').type(pin, { log: false })
+  if (savePin === true) {
+    cy.get('.switch-button').click().should('have.class', 'enabled')
+  } else {
+    cy.get('.switch-button').should('not.have.class', 'enabled')
+  }
+  cy.get('[data-cy=submit-input]').should('be.visible').click()
+})
+
+Cypress.Commands.add('importAccountEnterPassphrase', (userPassphrase) => {
+  cy.contains('Import Account').should('be.visible').click()
+  cy.contains(
+    'Enter your 12 word passphrase in exactly the same order your recovery seed was generated.',
+  ).should('be.visible')
+  cy.get('[data-cy=add-passphrase]')
+    .should('be.visible')
+    .type(userPassphrase, { log: false })
   cy.get('[data-cy=add-passphrase]').type('{enter}')
   cy.contains('Recover Account').should('be.visible').click()
   Cypress.on('uncaught:exception', (err, runnable) => false) // temporary until AP-48 gets fixed


### PR DESCRIPTION
**What this PR does** 📖
Add cypress tests for lock and unlock pin after creating and importing account flows
Added and modified cypress commands for import account
Fixed snapshots cypress tests to use a new import account and remove settings sections removed from applications
Modified plugins/index.js file for fix on Github actions requested by Sara

**Which issue(s) this PR fixes** 🔨
AP-617

**Special notes for reviewers** 🗒️

**Additional comments** 🎤

**Cypress Video** 📺
Pin Validations:

https://user-images.githubusercontent.com/35935591/155818199-70513c85-c74f-4fab-8034-ffe12136d7ee.mp4

Snapshots Tests:

https://user-images.githubusercontent.com/35935591/155818218-702435f6-bd44-445c-8898-d99a92d71aef.mp4



