### PR TITLE
test(cypress): add tests for chat bar options displayed

### DIFF
--- a/integration/chat-features.js
+++ b/integration/chat-features.js
@@ -2,19 +2,46 @@ const faker = require('faker')
 const randomNumber = faker.datatype.number() // generate random number
 const randomMessage = faker.lorem.sentence() // generate random sentence
 
-it('Chat - Send stuff on chat', () => {
-  cy.importAccount()
+describe('Chat Features Tests', () => {
+  it('Chat - Send stuff on chat', () => {
+    cy.importAccount()
 
-  //Validate profile name displayed
-  cy.chatFeaturesProfileName('asdad')
+    //Validate profile name displayed
+    cy.chatFeaturesProfileName('sadad')
 
-  // Click on hamburger menu if width < height
-  cy.get('.toggle-sidebar').should('be.visible').click()
+    // Click on hamburger menu if width < height
+    cy.get('.toggle-sidebar').should('be.visible').click()
 
-  //Validate message and emojis are sent
-  cy.chatFeaturesSendMessage(randomMessage)
-  cy.chatFeaturesSendEmoji('[title="smile"]', '😄')
+    //Validate message and emojis are sent
+    cy.chatFeaturesSendMessage(randomMessage)
+    cy.chatFeaturesSendEmoji('[title="smile"]', '😄')
 
-  //Validate message can be edited
-  cy.chatFeaturesEditMessage(randomMessage, randomNumber)
+    //Validate message can be edited
+    cy.chatFeaturesEditMessage(randomMessage, randomNumber)
+  })
+
+  it('Chat - Verify when clicking on Send Money a quick paypments pop-up appears', () => {
+    //Hover over on Send Money and Coming Soon tooltip will appear when clicking on its button
+    cy.get('#chatbar-controls > span > .tooltip-container')
+      .realHover()
+      .should('have.attr', 'data-tooltip', 'Send Money\nComing Soon')
+    cy.get('body').realHover({ position: 'topLeft' })
+  })
+
+  it('Chat - Verify when clicking on Emoji, the emoji picker appears', () => {
+    //Emoji picker is displayed  when clicking on its button
+    cy.get('#emoji-toggle').click()
+    cy.get('.navbar > .button-group > .active > #custom-cursor-area').should(
+      'contain',
+      'Emoji',
+    )
+    cy.get('#emoji-toggle').click()
+  })
+
+  it('Chat - Verify when clicking on Glyphs, the glyphs picker appears', () => {
+    //Glyphs picker is displayed when clicking on its button
+    cy.get('#glyph-toggle').click()
+    cy.get('.pack-list > .is-text').should('contain', 'Try using some glyphs')
+    cy.get('#glyph-toggle').click()
+  })
 })

--- a/integration/chat-features.js
+++ b/integration/chat-features.js
@@ -20,7 +20,7 @@ describe('Chat Features Tests', () => {
     cy.chatFeaturesEditMessage(randomMessage, randomNumber)
   })
 
-  it('Chat - Verify when clicking on Send Money a quick paypments pop-up appears', () => {
+  it('Chat - Verify when clicking on Send Money, coming soon appears', () => {
     //Hover over on Send Money and Coming Soon tooltip will appear when clicking on its button
     cy.get('#chatbar-controls > span > .tooltip-container')
       .realHover()

--- a/integration/create-account-negative-tests.js
+++ b/integration/create-account-negative-tests.js
@@ -50,7 +50,7 @@ it('Try to create account with NSFW image', () => {
   //Attempting to add NSFW image and validating error message is displayed
   const filepathNsfw = 'images/negative-create-account-test.png'
   cy.createAccountAddImage(filepathNsfw)
-  cy.get('.red', { timeout: 10000 }).should(
+  cy.get('.red', { timeout: 20000 }).should(
     'have.text',
     'Unable to upload file/s due to NSFW status',
   )

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@commitlint/config-conventional": "^16.2.1",
     "cypress-localstorage-commands": "^1.6.1",
     "cypress-plugin-snapshots": "^1.4.4",
+    "cypress-real-events": "^1.7.0",
     "husky": "^7.0.0",
     "pretty-quick": "^3.1.3"
   },

--- a/support/index.js
+++ b/support/index.js
@@ -1,2 +1,3 @@
 import './commands'
 import 'cypress-plugin-snapshots/commands'
+import 'cypress-real-events/support'


### PR DESCRIPTION
**What this PR does** 📖
- Adding cypress tests for chat bar options display
- Adding a cypress plugin for real events handling, since cypress cannot trigger a hover action natively 

**Which issue(s) this PR fixes** 🔨
AP-619

**Special notes for reviewers** 🗒️

**Additional comments** 🎤

**Cypress Video** 📺

https://user-images.githubusercontent.com/35935591/156067668-b0c31ea3-4068-49d7-9094-2266ae6f5822.mp4


