### PR TITLE
test(cypress): fix existing scripts setup, update snapshots plugin

### DIFF
--- a/integration/chat-features.js
+++ b/integration/chat-features.js
@@ -1,10 +1,12 @@
 const faker = require('faker')
+const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate random PIN
 const randomNumber = faker.datatype.number() // generate random number
 const randomMessage = faker.lorem.sentence() // generate random sentence
 
 describe('Chat Features Tests', () => {
   it('Chat - Send stuff on chat', () => {
-    cy.importAccount()
+    //Import account
+    cy.importAccount(randomPIN)
 
     //Validate profile name displayed
     cy.chatFeaturesProfileName('sadad')

--- a/integration/create-account-negative-tests.js
+++ b/integration/create-account-negative-tests.js
@@ -1,57 +1,57 @@
 const faker = require('faker')
+const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate random PIN
 const randomName = faker.internet.userName(name) // generate random name
 const randomStatus = faker.lorem.word() // generate random status
+const filepathNsfw = 'images/negative-create-account-test.png'
 
-it('Try to create account with PIN less than 5 digits', () => {
-  cy.visit('/')
-  //Enter PIN screen and add an invalid pin
-  cy.createAccountPINscreen('1')
+describe('Create Account - Negative Tests', () => {
+  it('Try to create account with PIN less than 5 digits', () => {
+    //Enter PIN screen and add an invalid pin
+    cy.createAccountPINscreen('1')
 
-  //Error message will be displayed
-  cy.contains('Pin must be at least 5 characters.')
-})
+    //Error message will be displayed
+    cy.contains('Pin must be at least 5 characters.')
+  })
 
-it('Try to create account without username', () => {
-  //Enter PIN screen
-  cy.visit('/')
-  cy.createAccountPINscreen('test001')
+  it('Try to create account without username', () => {
+    //Enter PIN screen
+    cy.createAccountPINscreen(randomPIN)
 
-  //Create or Import account selection screen
-  cy.createAccountSecondScreen()
+    //Create or Import account selection screen
+    cy.createAccountSecondScreen()
 
-  //Privacy Settings screen
-  cy.createAccountPrivacyToggles()
+    //Privacy Settings screen
+    cy.createAccountPrivacyTogglesGoNext()
 
-  //Recovery Seed Screen
-  cy.createAccountRecoverySeed()
+    //Recovery Seed Screen
+    cy.createAccountRecoverySeed()
 
-  //Clicking without adding a username will throw an error message
-  cy.get('[data-cy=sign-in-button]').click()
-  cy.contains('Username must be at least 5 characters.')
-})
+    //Clicking without adding a username will throw an error message
+    cy.get('[data-cy=sign-in-button]').click()
+    cy.contains('Username must be at least 5 characters.')
+  })
 
-it('Try to create account with NSFW image', () => {
-  cy.visit('/')
-  //Enter PIN screen
-  cy.createAccountPINscreen('test001')
+  it('Try to create account with NSFW image', () => {
+    //Enter PIN screen
+    cy.createAccountPINscreen(randomPIN)
 
-  //Create or Import account selection screen
-  cy.createAccountSecondScreen()
+    //Create or Import account selection screen
+    cy.createAccountSecondScreen()
 
-  //Privacy Settings screen
-  cy.createAccountPrivacyToggles()
+    //Privacy Settings screen
+    cy.createAccountPrivacyTogglesGoNext()
 
-  //Recovery Seed Screen
-  cy.createAccountRecoverySeed()
+    //Recovery Seed Screen
+    cy.createAccountRecoverySeed()
 
-  //Username and Status Input
-  cy.createAccountUserInput(randomName, randomStatus)
+    //Username and Status Input
+    cy.createAccountUserInput(randomName, randomStatus)
 
-  //Attempting to add NSFW image and validating error message is displayed
-  const filepathNsfw = 'images/negative-create-account-test.png'
-  cy.createAccountAddImage(filepathNsfw)
-  cy.get('.red', { timeout: 20000 }).should(
-    'have.text',
-    'Unable to upload file/s due to NSFW status',
-  )
+    //Attempting to add NSFW image and validating error message is displayed
+    cy.createAccountAddImage(filepathNsfw)
+    cy.get('.red', { timeout: 20000 }).should(
+      'have.text',
+      'Unable to upload file/s due to NSFW status',
+    )
+  })
 })

--- a/integration/create-account.js
+++ b/integration/create-account.js
@@ -1,84 +1,104 @@
 const faker = require('faker')
-const randomName = faker.internet.userName(name) // generate random name
-const randomStatus = faker.lorem.word() // generate random status
 const filepathCorrect = 'images/logo.png'
 const filepathNsfw = 'images/negative-create-account-test.png'
+const randomName = faker.internet.userName(name) // generate random name
+const randomStatus = faker.lorem.word() // generate random status
+const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate random PIN
 
-it('Create Account', () => {
-  cy.visit('/')
-  //Enter PIN screen
-  cy.createAccountPINscreen('test001')
+describe('Create Account Validations', () => {
+  it('Create Account', () => {
+    //Enter PIN screen
+    cy.createAccountPINscreen(randomPIN, false, true, false)
 
-  //Create or Import account selection screen
-  cy.createAccountSecondScreen()
+    //Create or Import account selection screen
+    cy.contains(
+      "We're going to create an account for you. On the next screen, you'll see a set of words. Screenshot this or write it down. This is the only way to backup your account.",
+    ).should('be.visible')
+    cy.get('.is-primary > #custom-cursor-area').should('be.visible')
+    cy.createAccountSecondScreen()
 
-  //Privacy Settings screen
-  cy.createAccountPrivacyToggles()
+    //Privacy Settings screen
+    cy.createAccountPrivacyToggles()
 
-  //Recovery Seed Screen
-  cy.createAccountRecoverySeed()
+    //Recovery Seed Screen
+    cy.get('.title').should('be.visible').should('contain', 'Recovery Seed')
+    cy.contains('I Saved It').should('be.visible')
+    cy.get('#custom-cursor-area').should('be.visible')
+    cy.createAccountRecoverySeed()
 
-  //Username and Status Input
-  cy.createAccountUserInput(randomName, randomStatus)
+    //Username and Status Input
+    cy.contains(
+      'Customize how the world sees you, choose something memorable.',
+      {
+        timeout: 10000,
+      },
+    ).should('be.visible')
+    cy.get('[data-cy=username-input]').should('be.visible')
+    cy.get('[data-cy=status-input]').should('be.visible')
+    cy.createAccountUserInput(randomName, randomStatus)
 
-  //User Image Input
-  cy.createAccountAddImage(filepathCorrect)
-  cy.contains('Crop', { timeout: 20000 }).should('be.visible').click()
+    //User Image Input
+    cy.createAccountAddImage(filepathCorrect)
+    cy.contains('Crop', { timeout: 30000 }).should('be.visible').click()
 
-  //Finishing Account Creation
-  cy.createAccountSubmit()
-})
+    //Finishing Account Creation
+    cy.createAccountSubmit()
+  })
 
-it('Create account with non-NSFW after attempting to load a NSFW image', () => {
-  cy.visit('/')
-  //Creating pin, clicking on buttons to continue to user data screen
-  cy.createAccountPINscreen('test001')
-  cy.createAccountSecondScreen()
-  cy.createAccountPrivacyToggles()
-  cy.createAccountRecoverySeed()
+  it('Create account with non-NSFW after attempting to load a NSFW image', () => {
+    //Creating pin
+    cy.createAccountPINscreen(randomPIN)
 
-  //Adding random data in user input fields
-  cy.createAccountUserInput(randomName, randomStatus)
+    //Clicking on buttons to continue to user data screen
+    cy.createAccountSecondScreen()
+    cy.createAccountPrivacyTogglesGoNext()
+    cy.createAccountRecoverySeed()
 
-  //Attempting to add NSFW image and validating error message is displayed
-  cy.createAccountAddImage(filepathNsfw)
-  cy.get('.red', { timeout: 30000 }).should(
-    'have.text',
-    'Unable to upload file/s due to NSFW status',
-  )
+    //Adding random data in user input fields
+    cy.createAccountUserInput(randomName, randomStatus)
 
-  //Now adding a non-NSFW image and validating user can pass to next step
-  cy.createAccountAddImage(filepathCorrect)
-  cy.contains('Crop', { timeout: 10000 }).click()
-  cy.get('.red').should('not.exist')
+    //Attempting to add NSFW image and validating error message is displayed
+    cy.createAccountAddImage(filepathNsfw)
+    cy.get('.red', { timeout: 30000 }).should(
+      'have.text',
+      'Unable to upload file/s due to NSFW status',
+    )
 
-  //Finishing Account Creation
-  cy.createAccountSubmit()
-})
+    //Now adding a non-NSFW image and validating user can pass to next step
+    cy.createAccountAddImage(filepathCorrect)
+    cy.contains('Crop', { timeout: 30000 }).click()
+    cy.get('.red').should('not.exist')
 
-it('Create account successfully without image after attempting to add a NSFW picture', () => {
-  cy.visit('/')
-  //Creating pin, clicking on buttons to continue to user data screen
-  cy.createAccountPINscreen('test001')
-  cy.createAccountSecondScreen()
-  cy.createAccountPrivacyToggles()
-  cy.createAccountRecoverySeed()
+    //Finishing Account Creation
+    cy.createAccountSubmit()
+  })
 
-  //Adding random data in user input fields
-  cy.createAccountUserInput(randomName, randomStatus)
+  it('Create account successfully without image after attempting to add a NSFW picture', () => {
+    //Creating pin
+    cy.createAccountPINscreen(randomPIN)
 
-  //Attempting to add NSFW image and validating error message is displayed
-  cy.createAccountAddImage(filepathNsfw)
-  cy.get('.red', { timeout: 30000 }).should(
-    'have.text',
-    'Unable to upload file/s due to NSFW status',
-  )
+    //Clicking on buttons to continue to user data screen
 
-  //User is still able to sign in and NSFW image will not be loaded
-  cy.createAccountSubmit()
+    cy.createAccountSecondScreen()
+    cy.createAccountPrivacyTogglesGoNext()
+    cy.createAccountRecoverySeed()
 
-  //Validating profile picture is null and default satellite circle is displayed
-  cy.get('.user-state > .is-rounded > .satellite-circle', {
-    timeout: 40000,
-  }).should('exist')
+    //Adding random data in user input fields
+    cy.createAccountUserInput(randomName, randomStatus)
+
+    //Attempting to add NSFW image and validating error message is displayed
+    cy.createAccountAddImage(filepathNsfw)
+    cy.get('.red', { timeout: 30000 }).should(
+      'have.text',
+      'Unable to upload file/s due to NSFW status',
+    )
+
+    //User is still able to sign in and NSFW image will not be loaded
+    cy.createAccountSubmit()
+
+    //Validating profile picture is null and default satellite circle is displayed
+    cy.get('.user-state > .is-rounded > .satellite-circle', {
+      timeout: 60000,
+    }).should('exist')
+  })
 })

--- a/integration/import-account-negative-tests.js
+++ b/integration/import-account-negative-tests.js
@@ -1,28 +1,33 @@
-it('Verify error when adding a wrong order passphrase', () => {
-  cy.visit('/')
-  cy.get('[data-cy=add-input]').type('test001', { log: false })
-  cy.get('[data-cy=submit-input]').click()
-  cy.contains('Import Account').click()
-  cy.get('[data-cy=add-passphrase]').type(
-    'over tilt regret diamond rubber example there fire roof sheriff always boring',
-    { log: false },
-  )
-  cy.get('[data-cy=add-passphrase]').type('{enter}')
-  cy.contains('Recover Account').click()
-  cy.contains(
-    'We were unable to verify your passphrase. Please check it and try again.',
-  ).should('be.visible')
-})
+const faker = require('faker')
+const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate random PIN
 
-it('Verify behavior when adding less than 12 words', () => {
-  cy.visit('/')
-  cy.get('[data-cy=add-input]').type('test001', { log: false })
-  cy.get('[data-cy=submit-input]').click()
-  cy.contains('Import Account').click()
-  cy.get('[data-cy=add-passphrase]').type(
-    'over tilt regret diamond rubber example there fire roof sheriff always',
-    { log: false },
-  )
-  cy.get('[data-cy=add-passphrase]').type('{enter}')
-  cy.get('.recover-account').should('be.disabled')
+describe('Import Account - Negative Tests', () => {
+  it('Verify error when adding a wrong order passphrase', () => {
+    cy.importAccountPINscreen(randomPIN)
+    cy.contains('Import Account', { timeout: 60000 }).click()
+    cy.get('[data-cy=add-passphrase]', { timeout: 30000 })
+      .should('be.visible')
+      .type(
+        'over tilt regret diamond rubber example there fire roof sheriff always boring',
+        { log: false },
+      )
+    cy.get('[data-cy=add-passphrase]').should('be.visible').type('{enter}')
+    cy.contains('Recover Account').click()
+    cy.contains(
+      'We were unable to verify your passphrase. Please check it and try again.',
+    ).should('be.visible')
+  })
+
+  it('Verify behavior when adding less than 12 words', () => {
+    cy.importAccountPINscreen(randomPIN)
+    cy.contains('Import Account', { timeout: 60000 }).click()
+    cy.get('[data-cy=add-passphrase]', { timeout: 30000 })
+      .should('be.visible')
+      .type(
+        'over tilt regret diamond rubber example there fire roof sheriff always',
+        { log: false },
+      )
+    cy.get('[data-cy=add-passphrase]').should('be.visible').type('{enter}')
+    cy.get('.recover-account').should('be.disabled')
+  })
 })

--- a/integration/import-account.js
+++ b/integration/import-account.js
@@ -1,13 +1,34 @@
-it('Import account', () => {
-  cy.importAccount()
-})
+const faker = require('faker')
+const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate random PIN
 
-it('Import account - verify suggestions', () => {
-  cy.visit('/')
-  cy.get('[data-cy=add-input]').type('test001', { log: false })
-  cy.get('[data-cy=submit-input]').click()
-  cy.contains('Import Account').click()
-  cy.get('[data-cy=add-passphrase]').type('b')
-  cy.contains('baby').click()
-  cy.get('.tag').should('be.visible')
+describe('Import Account Validations', () => {
+  it('Import account - verify suggestions', () => {
+    cy.importAccountPINscreen(randomPIN)
+    cy.contains('Import Account', { timeout: 60000 })
+      .should('be.visible')
+      .click()
+    cy.get('[data-cy=add-passphrase]').should('be.visible').type('b')
+    cy.contains('baby').click()
+    cy.get('.tag').should('be.visible')
+  })
+
+  it('Import account', () => {
+    cy.importAccountPINscreen(randomPIN, false, true, false)
+    cy.contains('Import Account', { timeout: 60000 })
+      .should('be.visible')
+      .click()
+    cy.contains(
+      'Enter your 12 word passphrase in exactly the same order your recovery seed was generated.',
+    ).should('be.visible')
+    cy.get('[data-cy=add-passphrase]').should('be.visible')
+    cy.get('[data-cy=add-passphrase]')
+      .should('not.be.disabled')
+      .type(
+        'boring over tilt regret diamond rubber example there fire roof sheriff always',
+        { log: false },
+      )
+    cy.get('[data-cy=add-passphrase]').should('be.visible').type('{enter}')
+    cy.contains('Recover Account').should('be.visible').click()
+    Cypress.on('uncaught:exception', (err, runnable) => false) // temporary until AP-48 gets fixed
+  })
 })

--- a/integration/localstorage-validations.js
+++ b/integration/localstorage-validations.js
@@ -1,14 +1,18 @@
+const faker = require('faker')
+const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate random PIN
+
 describe('Verify passphrase does not get stored in localstorage', () => {
   it('Passphrase in localstorage does not exist before creating account', () => {
-    cy.visit('/')
-    cy.contains('Create Account Pin').then(() => {
-      cy.validatePassphraseLocalStorage()
+    cy.visit('/').then(() => {
+      cy.contains('Create Account Pin', { timeout: 30000 }).then(() => {
+        cy.validatePassphraseLocalStorage()
+      })
     })
   })
 
   it.skip('Create Account and validate localstorage values are as expected', () => {
     // Create Account process executed
-    cy.createAccount()
+    cy.createAccount(randomPIN)
 
     //Wait until main page is loaded after creating account
     cy.get('.user-state > .is-rounded > .satellite-circle', {
@@ -22,18 +26,19 @@ describe('Verify passphrase does not get stored in localstorage', () => {
   })
 
   it('Passphrase in localstorage does not exist before importing an account', () => {
-    cy.visit('/')
-    cy.contains('Create Account Pin').then(() => {
-      cy.validatePassphraseLocalStorage()
+    cy.visit('/').then(() => {
+      cy.contains('Create Account Pin', { timeout: 30000 }).then(() => {
+        cy.validatePassphraseLocalStorage()
+      })
     })
   })
 
   it.skip('Import Account and verify passphrase is not saved in localstorage', () => {
     // Import Account process executed
-    cy.importAccount()
+    cy.importAccount(randomPIN)
 
     //Wait until main page is loaded after importing account
-    cy.contains('asdad', { timeout: 60000 }).should('be.visible')
+    cy.contains('sadad', { timeout: 60000 }).should('be.visible')
 
     // Go to URL and validate that previous passphrase is not stored in localstorage
     cy.visit('/').then(() => {

--- a/integration/mobiles-responsiveness.js
+++ b/integration/mobiles-responsiveness.js
@@ -1,6 +1,7 @@
 import { data } from '../fixtures/mobile-devices.json'
 
 const faker = require('faker')
+const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate random PIN
 const randomName = faker.internet.userName(name) // generate random name
 const randomStatus = faker.lorem.word() // generate random status
 const filepathCorrect = 'images/logo.png'
@@ -10,18 +11,14 @@ const randomMessage = faker.lorem.sentence() // generate random sentence
 describe('Run responsiveness tests on several devices', () => {
   data.allDevices.forEach((item) => {
     it(`Create Account on ${item.description}`, () => {
-      //Visiting main page and changing viewport
-      cy.visit('/')
       cy.viewport(item.width, item.height)
-
-      //Enter PIN screen
-      cy.createAccountPINscreen('test001')
+      cy.createAccountPINscreen(randomPIN)
 
       //Create or Import account selection screen
       cy.createAccountSecondScreen()
 
       //Privacy Settings screen
-      cy.createAccountPrivacyToggles()
+      cy.createAccountPrivacyTogglesGoNext()
 
       //Recovery Seed Screen
       cy.createAccountRecoverySeed()
@@ -31,7 +28,7 @@ describe('Run responsiveness tests on several devices', () => {
 
       //User Image Input
       cy.createAccountAddImage(filepathCorrect)
-      cy.contains('Crop', { timeout: 20000 }).should('be.visible').click()
+      cy.contains('Crop', { timeout: 30000 }).should('be.visible').click()
 
       //Finishing Account Creation
       cy.createAccountSubmit()
@@ -39,7 +36,7 @@ describe('Run responsiveness tests on several devices', () => {
 
     it(`Import Account on ${item.description}`, () => {
       cy.viewport(item.width, item.height)
-      cy.importAccount()
+      cy.importAccount(randomPIN)
     })
 
     it(`Chat Features on ${item.description}`, () => {
@@ -47,7 +44,7 @@ describe('Run responsiveness tests on several devices', () => {
       cy.viewport(item.width, item.height)
 
       //Validate profile name displayed
-      cy.chatFeaturesProfileName('asdad')
+      cy.chatFeaturesProfileName('sadad')
 
       // Click on hamburger menu if width < height
       cy.get('.toggle-sidebar').should('be.visible').click()
@@ -61,8 +58,9 @@ describe('Run responsiveness tests on several devices', () => {
     })
 
     it(`Release Notes Screen on ${item.description}`, () => {
-      cy.viewport(item.width, item.height)
-      cy.visit('/')
+      cy.visit('/').then(() => {
+        cy.viewport(item.width, item.height)
+      })
       cy.releaseNotesScreenValidation()
     })
   })

--- a/integration/pin-unlock-validations.js
+++ b/integration/pin-unlock-validations.js
@@ -1,11 +1,12 @@
+const faker = require('faker')
 const userPassphrase =
   'boring over tilt regret diamond rubber example there fire roof sheriff always'
+const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate random PIN
 
 describe('Unlock pin should be persisted when store pin is enabled', () => {
   it('Create Account with store pin disabled', () => {
     //Go to URL, add a PIN and make sure that toggle for save pin is disabled
-    cy.visit('/')
-    cy.createAccountPINscreen('test001', false)
+    cy.createAccountPINscreen(randomPIN, false, false, false)
 
     //Follow the next steps to create an account
     cy.createAccountSecondScreen()
@@ -27,8 +28,7 @@ describe('Unlock pin should be persisted when store pin is enabled', () => {
 
   it('Create Account with store pin enabled', () => {
     //Go to URL, add a PIN and make sure that toggle for save pin is enabled
-    cy.visit('/')
-    cy.createAccountPINscreen('test002', true)
+    cy.createAccountPINscreen(randomPIN, true, false, false)
 
     //Follow the next steps to create an account
     cy.createAccountSecondScreen()
@@ -52,10 +52,7 @@ describe('Unlock pin should be persisted when store pin is enabled', () => {
 
   it('Import Account with store pin disabled', () => {
     //Go to URL, add a PIN and make sure that toggle for save pin is disabled
-    cy.clearLocalStorage().then(() => {
-      cy.visit('/')
-      cy.importAccountPINscreen('test003', false)
-    })
+    cy.importAccountPINscreen(randomPIN, false, false, false)
 
     //Follow the next steps to import an account
     cy.importAccountEnterPassphrase(userPassphrase)
@@ -73,8 +70,7 @@ describe('Unlock pin should be persisted when store pin is enabled', () => {
 
   it('Import Account with store pin enabled', () => {
     //Go to URL, add a PIN and make sure that toggle for save pin is enabled
-    cy.visit('/')
-    cy.importAccountPINscreen('test004', true)
+    cy.importAccountPINscreen(randomPIN, true, false, false)
 
     //Follow the next steps to import an account
     cy.importAccountEnterPassphrase(userPassphrase)

--- a/integration/privacy-page-toggles.js
+++ b/integration/privacy-page-toggles.js
@@ -1,92 +1,96 @@
 const faker = require('faker')
+const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate random PIN
 const randomName = faker.internet.userName(name) // generate random name
 const randomStatus = faker.lorem.word() // generate random status
+
 //Creating two arrays to compare values displayed in toggle switches on both screens
 let toggleStatusSaved = []
 let toggleStatusProfile = []
 
-before(() => {
-  //Adding pin to continue to toggles switches screen
-  cy.visit('/')
-  //Enter PIN screen
-  cy.createAccountPINscreen('test001')
+describe('Privacy Page Toggles Tests', () => {
+  before(() => {
+    //Adding pin to continue to toggles switches screen
+    cy.createAccountPINscreen(randomPIN)
 
-  //Create or Import account selection screen
-  cy.createAccountSecondScreen()
-})
-
-/* Commenting code below because tests will fail due to bug AP-795 
-switch for Register Username on privacy settings
-it('Privacy page - Verify all toggles can be switched to enable', () => {
-    cy.get('.switch-button').each(($btn, index, $List) => {
-        if (!($btn.hasClass('enabled'))) {
-            cy.wrap($btn).click().should('have.class', 'enabled')
-        } else {
-            cy.wrap($btn).should('have.class', 'enabled')     
-        }
-    })
-})
-
-it('Privacy page - Verify all toggles can be switched to disabled', () => {
-    cy.get('.switch-button').each(($btn, index, $List) => {
-        if ($btn.hasClass('enabled')) {
-            cy.wrap($btn).click().should('not.have.class', 'enabled')
-        } else {
-            cy.wrap($btn).should('not.have.class', 'enabled')     
-        }
-    })
-})
-*/
-
-it('Privacy page - Verify all toggles switches work as should', () => {
-  //Validating each toggle, checking status is correct after clicking them.
-  //Finally, saving values into an array for later comparison
-  cy.get('.switch-button').each(($btn, index, $List) => {
-    if ($btn.hasClass('enabled')) {
-      cy.wrap($btn).click().should('not.have.class', 'enabled')
-      toggleStatusSaved.push(false)
-    } else {
-      cy.wrap($btn).click().should('have.class', 'enabled')
-      toggleStatusSaved.push(true)
-    }
+    //Create or Import account selection screen
+    cy.createAccountSecondScreen()
   })
-})
 
-it('Privacy page - Verify user can still proceed after adjusting switches', () => {
-  //Going to Recovery Seed screen and clicking on button to go to next screen
-  cy.get('#custom-cursor-area').click()
+  /* Commenting code below because tests will fail due to bug AP-795 
+  switch for Register Username on privacy settings
+  it('Privacy page - Verify all toggles can be switched to enable', () => {
+      cy.get('.switch-button').each(($btn, index, $List) => {
+          if (!($btn.hasClass('enabled'))) {
+              cy.wrap($btn).click().should('have.class', 'enabled')
+          } else {
+              cy.wrap($btn).should('have.class', 'enabled')     
+          }
+      })
+  })
+  
+  it('Privacy page - Verify all toggles can be switched to disabled', () => {
+      cy.get('.switch-button').each(($btn, index, $List) => {
+          if ($btn.hasClass('enabled')) {
+              cy.wrap($btn).click().should('not.have.class', 'enabled')
+          } else {
+              cy.wrap($btn).should('not.have.class', 'enabled')     
+          }
+      })
+  })
+  */
 
-  //Recovery Seed Screen
-  cy.createAccountRecoverySeed()
-
-  //Username and Status Input
-  cy.createAccountUserInput(randomName, randomStatus)
-
-  //Click on button, validate buffering screen and that user is redirected to friends/list
-  cy.createAccountSubmit()
-  cy.url({ timeout: 30000 }).should('contain', 'friends/list')
-})
-
-it('Profile - Verify the toggles user added when signing up are on the same status when user goes to settings', () => {
-  //Going to Settings and Privacy screen
-  cy.get('[data-tooltip="Settings"]').click()
-  cy.contains('Privacy').click()
-  //Storing the values from toggle switches status of Settings screen into an array
-  cy.get('.switch-button')
-    .each(($btn, index, $List) => {
+  it('Privacy page - Verify all toggles switches work as should', () => {
+    //Validating each toggle, checking status is correct after clicking them.
+    //Finally, saving values into an array for later comparison
+    cy.get('.switch-button', { timeout: 30000 }).each(($btn, index, $List) => {
       if ($btn.hasClass('enabled')) {
-        toggleStatusProfile.push(true)
+        cy.wrap($btn).click().should('not.have.class', 'enabled')
+        toggleStatusSaved.push(false)
       } else {
-        toggleStatusProfile.push(false)
+        cy.wrap($btn).click().should('have.class', 'enabled')
+        toggleStatusSaved.push(true)
       }
     })
-    .then(() => {
-      //Comparison of both arrays to ensure that are deep equal
-      expect(toggleStatusProfile).to.deep.equal(toggleStatusSaved)
-    })
-})
+    cy.get('#custom-cursor-area').click()
+  })
 
-it('Profile - Verify user can’t update the register name publicly toggle on settings', () => {
-  //Identify the first switch button and ensure that is locked
-  cy.get('.switch-button').first().should('have.class', 'locked')
+  it('Privacy page - Verify user can still proceed after adjusting switches', () => {
+    //Recovery Seed Screen
+    cy.createAccountRecoverySeed()
+
+    //Username and Status Input
+    cy.createAccountUserInput(randomName, randomStatus)
+
+    //Click on button, validate buffering screen and that user is redirected to friends/list
+    cy.createAccountSubmit()
+    cy.get('.user-state > .is-rounded > .satellite-circle', {
+      timeout: 120000,
+    }).should('be.visible')
+  })
+
+  it('Profile - Verify the toggles user added when signing up are on the same status when user goes to settings', () => {
+    //Going to Settings and Privacy screen
+    cy.get('[data-tooltip="Settings"] > .is-rounded > svg', {
+      timeout: 30000,
+    }).click()
+    cy.contains('Privacy').click()
+    //Storing the values from toggle switches status of Settings screen into an array
+    cy.get('.switch-button')
+      .each(($btn, index, $List) => {
+        if ($btn.hasClass('enabled')) {
+          toggleStatusProfile.push(true)
+        } else {
+          toggleStatusProfile.push(false)
+        }
+      })
+      .then(() => {
+        //Comparison of both arrays to ensure that are deep equal
+        expect(toggleStatusProfile).to.deep.equal(toggleStatusSaved)
+      })
+  })
+
+  it('Profile - Verify user can’t update the register name publicly toggle on settings', () => {
+    //Identify the first switch button and ensure that is locked
+    cy.get('.switch-button').first().should('have.class', 'locked')
+  })
 })

--- a/integration/snapshots-test.js
+++ b/integration/snapshots-test.js
@@ -1,26 +1,23 @@
 const faker = require('faker')
-const randomName = faker.internet.userName(name) // generate random name
-const randomStatus = faker.lorem.word() // generate random status
+const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate random PIN
 const recoverySeed =
   'black blossom pink damage together artwork coil west clown turn chimney physical'
+const randomName = faker.internet.userName(name) // generate random name
+const randomStatus = faker.lorem.word() // generate random status
 
 describe('Snapshots Testing', () => {
-  it('Import account', () => {
-    //Import account and snapshot on each screen
-    //Enter PIN Screen
-    cy.visit('/')
-    cy.viewport(1400, 1000)
-    cy.snapshotTestGet('.subtitle', 'Create Account Pin')
-    cy.get('[data-cy=add-input]')
-      .should('be.visible')
-      .type('test001', { log: false })
-    cy.get('[data-cy=submit-input]').should('be.visible').click()
+  //Import account and snapshot on each screen
+  Cypress.on('uncaught:exception', (err, runnable) => false) // temporary until AP-48 gets fixed
+  it('Import account - PIN screen', () => {
+    cy.importAccountPINscreen(randomPIN, false, false, true)
+  })
 
-    //Create or Import Account Selection Screen
+  it('Import account - Create or Import Account Selection screen', () => {
     cy.snapshotTestContains('Import Account')
-    cy.contains('Import Account').click()
+    cy.contains('Import Account', { timeout: 30000 }).click()
+  })
 
-    //Enter the passphrase screen
+  it('Import account - Enter passphrase screen', () => {
     cy.snapshotTestContains(
       'Enter your 12 word passphrase in exactly the same order your recovery seed was generated.',
     )
@@ -28,106 +25,126 @@ describe('Snapshots Testing', () => {
       .should('be.visible')
       .type(recoverySeed, { log: false })
     cy.get('[data-cy=add-passphrase]').type('{enter}')
+  })
 
-    //Snapshot after adding recovery seed
-    cy.snapshotTestContains('Recover Account')
+  it('Import account - Screen after adding recovery seed', () => {
+    cy.snapshotTestContains('Recover Account', 20000)
     cy.contains('Recover Account').click()
-    Cypress.on('uncaught:exception', (err, runnable) => false) // temporary until AP-48 gets fixed
+  })
 
-    //Snapshots on buffering screen and main screen
+  it('Import account - Buffering screen', () => {
     cy.snapshotTestContains('Linking Satellites...', 60000)
-    cy.snapshotTestContains('SnapQA', 60000)
+  })
 
-    // Go to files
+  it('Import account - Main Screen Loaded', () => {
+    cy.snapshotTestContains('SnapQA', 60000)
+  })
+
+  it('Import account - Go to files', () => {
     cy.get('.sidebar-nav > .is-dark > #custom-cursor-area').click()
     cy.snapshotTestGet('.switcher-container > .is-text', 'Files')
+  })
 
-    // Go to friends
+  it('Import account - Go to friends', () => {
     cy.get(
       '[style="position: relative;"] > .sidebar-full-btn > #custom-cursor-area',
     ).click()
     cy.snapshotTestContains('Add Friend')
+  })
 
-    // Go to a chat
-    cy.get('[data-tooltip="Message"]').click()
-    cy.snapshotTestContains('connected', 20000)
+  it('Import account - Go to a chat', () => {
+    cy.get('[data-tooltip="Message"]').first().click()
+    cy.snapshotTestContains('connected', 60000)
+  })
 
-    // Click on emojis
+  it('Import account - Click on emojis', () => {
     cy.get('#emoji-toggle').click()
     cy.snapshotTestGet(
       '.navbar > .button-group > .active > #custom-cursor-area',
       'Emoji',
     )
+  })
 
-    // Click on glyphs
+  it('Import account - Click on glyphs', () => {
     cy.get('#emoji-toggle').click()
     cy.get('#glyph-toggle').click()
     cy.snapshotTestGet('.pack-list > .is-text', 'Try using some glyphs')
     cy.get('#glyph-toggle').click()
+  })
 
+  it('Import account - Settings - General - Personalize', () => {
     // Go to each settings option and snapshot each
-    // Go to Settings - General - Personalize
     cy.get('[data-tooltip="Settings"] > .is-rounded > svg').click()
     cy.snapshotTestContains('Personalize Satellite')
+  })
 
-    // Go to Settings - General - Profile
+  it('Import account - Settings - General - Profile', () => {
     cy.openSettingsMenuOption('Profile')
     cy.get('.title').should('contain', 'Profile')
     cy.snapshotTestContains('Profile')
+  })
 
-    // Go to Settings - General - Audio & Video
+  it('Import account - Settings - General - Audio & Video', () => {
     cy.openSettingsMenuOption('Audio & Video')
-    cy.snapshotTestContains('Audio Sources')
+    cy.snapshotTestContains('Audio Input')
+  })
 
-    // Go to Settings - General - Keybinds
+  it('Import account - Settings - General - Keybinds', () => {
     cy.openSettingsMenuOption('Keybinds')
     cy.snapshotTestContains('Default Keybinds')
+  })
 
-    // Go to Settings - General - Accounts & Devices
+  it('Import account - Settings - General - Accounts & Devices', () => {
     cy.openSettingsMenuOption('Accounts & Devices')
     cy.get('.column > .title').should('contain', 'Accounts & Devices')
     cy.snapshotTestContains('Accounts & Devices')
+  })
 
-    // Go to Settings - General - Privacy
+  it('Import account - Settings - General - Privacy', () => {
     cy.openSettingsMenuOption('Privacy')
     cy.snapshotTestContains('Privacy Settings')
+  })
 
-    // Go to Settings - Realms & Security - Realms
+  it('Import account - Settings - Realms & Security - Realms', () => {
     cy.openSettingsMenuOption('Realms')
     cy.get('.column > .title').should('contain', 'Realms')
     cy.snapshotTestContains('Realms')
+  })
 
-    // Go to Settings - Realms & Security - Storage
+  it('Import account - Settings - Realms & Security - Storage', () => {
     cy.openSettingsMenuOption('Storage')
     cy.get('.column > .title').should('contain', 'Storage')
     cy.snapshotTestContains('Storage')
+  })
 
-    // Go to Settings - Realms & Security - Network
+  it('Import account - Settings - Realms & Security - Network', () => {
     cy.openSettingsMenuOption('Network')
     cy.get('.column > .title').should('contain', 'Network')
     cy.snapshotTestContains('Network')
+  })
 
-    // Go to Settings - Developer - App Info
+  it('Import account - Settings - Developer - App Info', () => {
     cy.openSettingsMenuOption('App Info')
     cy.snapshotTestContains('Application Info')
     cy.get('.ps-container > .close-button').click()
   })
 
-  it('Create account', () => {
+  it('Create Account - PIN screen', () => {
     //Open URL and snapshot
-    cy.visit('/')
-    cy.viewport(1400, 1000)
-    cy.snapshotTestGet('.subtitle', 'Create Account Pin')
-    cy.createAccountPINscreen('test001')
+    cy.createAccountPINscreen(randomPIN, false, false, true)
+  })
 
-    //Create or Import account selection screen
+  it('Create Account - Create or Import Account Selection screen', () => {
     cy.snapshotTestContains('Create Account')
     cy.createAccountSecondScreen()
+  })
 
-    //Privacy Settings screen
+  it('Create Account - Privacy Settings screen', () => {
     cy.snapshotTestContains('Privacy Settings')
-    cy.createAccountPrivacyToggles()
+    cy.createAccountPrivacyTogglesGoNext()
+  })
 
+  it('Create Account - User Input Screen', () => {
     //Recovery Seed Screen then User Input Snapshot
     cy.createAccountRecoverySeed().then(() => {
       cy.snapshotTestContains(
@@ -135,7 +152,9 @@ describe('Snapshots Testing', () => {
         30000,
       )
     })
+  })
 
+  it('Create Account - Buffering screen after submission', () => {
     //User input fill and finishing account creation
     cy.createAccountUserInput(randomName, randomStatus)
     cy.createAccountSubmit()

--- a/integration/version-release-notes.js
+++ b/integration/version-release-notes.js
@@ -1,4 +1,7 @@
-it('Release notes appear when clicking on version number', () => {
-  cy.visit('/')
-  cy.releaseNotesScreenValidation()
+describe('Version Release Notes Tests', () => {
+  it('Release notes appear when clicking on version number', () => {
+    cy.visit('/').then(() => {
+      cy.releaseNotesScreenValidation()
+    })
+  })
 })

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   "devDependencies": {
     "@commitlint/cli": "^16.2.1",
     "@commitlint/config-conventional": "^16.2.1",
+    "cypress-image-snapshot": "^4.0.1",
     "cypress-localstorage-commands": "^1.6.1",
-    "cypress-plugin-snapshots": "^1.4.4",
     "cypress-real-events": "^1.7.0",
     "husky": "^7.0.0",
     "pretty-quick": "^3.1.3"

--- a/plugins/index.js
+++ b/plugins/index.js
@@ -1,12 +1,5 @@
-const { initPlugin } = require('cypress-plugin-snapshots/plugin')
+const { addMatchImageSnapshotPlugin } = require('cypress-image-snapshot/plugin')
 
 module.exports = (on, config) => {
-  on('before:browser:launch', (browser, launchOptions) => {
-    if (browser.name === 'chrome' && browser.isHeadless) {
-      launchOptions.args.push('--disable-gpu')
-      return launchOptions
-    }
-  })
-  initPlugin(on, config)
-  return config
+  addMatchImageSnapshotPlugin(on, config)
 }

--- a/support/index.js
+++ b/support/index.js
@@ -1,3 +1,2 @@
 import './commands'
-import 'cypress-plugin-snapshots/commands'
 import 'cypress-real-events/support'


### PR DESCRIPTION
**What this PR does** 📖
- Fixes for all existing cypress scripts to avoid timeout and cache not deleted issues
- Changes in cypress commands to avoid timeout issues and ensuring that each test needing cache/cookies removed have this step being executed before running the test
- Changing snapshots plugin for one that can run when running all integration specs

**Which issue(s) this PR fixes** 🔨
AP-930

**Special notes for reviewers** 🗒️
Changes required in cypress.json file from Core-PWA repository
When executing for the first time, we need to grab the snapshots using "--env updateSnapshots=true" when running all integration specs or the snapshots spec

**Additional comments** 🎤
These should be one time changes and going forward when using import/create account commands for new scripts created, test cases should run without issues!

**Cypress Video** 📺
Too many videos since this change affects all test specs, I can share them separately.
