### PR TITLE
test(cypress): add chat features tests between two accounts

### DIFF
--- a/fixtures/test-file.txt
+++ b/fixtures/test-file.txt
@@ -1,0 +1,1 @@
+This is a sample test file to share between users

--- a/integration/chat-features.js
+++ b/integration/chat-features.js
@@ -2,11 +2,13 @@ const faker = require('faker')
 const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate random PIN
 const randomNumber = faker.datatype.number() // generate random number
 const randomMessage = faker.lorem.sentence() // generate random sentence
+const recoverySeed =
+  'boring over tilt regret diamond rubber example there fire roof sheriff always{enter}'
 
 describe('Chat Features Tests', () => {
   it('Chat - Send stuff on chat', () => {
     //Import account
-    cy.importAccount(randomPIN)
+    cy.importAccount(randomPIN, recoverySeed)
 
     //Validate profile name displayed
     cy.chatFeaturesProfileName('sadad')

--- a/integration/chat-pair-features.js
+++ b/integration/chat-pair-features.js
@@ -1,0 +1,124 @@
+const faker = require('faker')
+const recoverySeedAccountOne =
+  'core radio verb scout shuffle moment pottery maple need ostrich train around{enter}'
+const recoverySeedAccountTwo =
+  'festival drastic visual aisle noble off cousin stairs arm seat agent table{enter}'
+const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate random PIN
+const randomMessage = faker.lorem.sentence() // generate random sentence
+const imageLocalPath = 'cypress/fixtures/images/logo.png'
+const fileLocalPath = 'cypress/fixtures/test-file.txt'
+let glyphURL, imageURL, fileURL
+
+describe('Chat features with two accounts - First User', () => {
+  before(() => {
+    //Import first account
+    cy.importAccount(randomPIN, recoverySeedAccountOne)
+  })
+
+  it('Ensure chat window from second account is displayed', () => {
+    //Validate Chat Screen is loaded
+    cy.contains('Chat User A', { timeout: 180000 }).should('be.visible')
+  })
+
+  it('Send message to user B', () => {
+    cy.chatFeaturesSendMessage(randomMessage)
+    cy.contains(randomMessage).last().scrollIntoView().should('be.visible')
+  })
+
+  it('Send emoji to user B', () => {
+    cy.chatFeaturesSendEmoji('[title="smile"]', '😄')
+    cy.get('[data-cy=chat-message] > span')
+      .last()
+      .scrollIntoView()
+      .should('have.text', '😄')
+  })
+
+  it('Send glyph to user B', () => {
+    cy.chatFeaturesSendGlyph()
+    cy.get('[data-cy=chat-glyph]')
+      .last()
+      .scrollIntoView()
+      .should('be.visible')
+      .invoke('attr', 'src')
+      .then((glyphSrcValue) => {
+        glyphURL = glyphSrcValue
+      })
+  })
+
+  it('Send image to user B', () => {
+    cy.chatFeaturesSendImage(imageLocalPath)
+    cy.get('[data-cy=chat-image]')
+      .last()
+      .scrollIntoView()
+      .should('be.visible')
+      .invoke('attr', 'src')
+      .then((imgSrcValue) => {
+        imageURL = imgSrcValue
+      })
+  })
+
+  it('Send file to user B', () => {
+    cy.chatFeaturesSendFile(fileLocalPath)
+    cy.get('[data-cy=chat-file]')
+      .last()
+      .scrollIntoView()
+      .should('be.visible')
+      .invoke('attr', 'href')
+      .then((fileSrcValue) => {
+        fileURL = fileSrcValue
+      })
+  })
+
+  it('Ensure chat window from second account is displayed', () => {
+    cy.importAccount(randomPIN, recoverySeedAccountTwo)
+    cy.contains('Chat User B', { timeout: 180000 }).should('be.visible')
+  })
+
+  it('Assert message received from user A', () => {
+    cy.contains(randomMessage).last().scrollIntoView().should('be.visible')
+  })
+
+  it('Assert emoji received from user A', () => {
+    cy.get('[data-cy=chat-message] > span')
+      .last()
+      .scrollIntoView()
+      .should('have.text', '😄')
+  })
+
+  it('Assert glyph received from user A', () => {
+    cy.get('[data-cy=chat-glyph]')
+      .last()
+      .scrollIntoView()
+      .should('be.visible')
+      .invoke('attr', 'src')
+      .then((glyphSecondAccountSrc) => {
+        expect(glyphSecondAccountSrc).to.be.eq(glyphURL)
+      })
+  })
+
+  it('Assert image received from user A', () => {
+    cy.get('[data-cy=chat-image]')
+      .last()
+      .scrollIntoView()
+      .should('be.visible')
+      .invoke('attr', 'src')
+      .then((imageSecondAccountSrc) => {
+        expect(imageSecondAccountSrc).to.be.eq(imageURL)
+      })
+  })
+
+  it('Assert file received from user A', () => {
+    cy.get('[data-cy=chat-file]')
+      .last()
+      .scrollIntoView()
+      .should('be.visible')
+      .invoke('attr', 'href')
+      .then((fileSecondAccountSrc) => {
+        expect(fileSecondAccountSrc).to.be.eq(fileURL)
+      })
+  })
+
+  it('Assert timestamp is displayed when user A sends a message', () => {
+    cy.get('[data-cy=chat-timestamp]').last().should('contain', 'minutes ago')
+  })
+})

--- a/integration/localstorage-validations.js
+++ b/integration/localstorage-validations.js
@@ -1,5 +1,7 @@
 const faker = require('faker')
 const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate random PIN
+const recoverySeed =
+  'boring over tilt regret diamond rubber example there fire roof sheriff always{enter}'
 
 describe('Verify passphrase does not get stored in localstorage', () => {
   it('Passphrase in localstorage does not exist before creating account', () => {
@@ -37,7 +39,7 @@ describe('Verify passphrase does not get stored in localstorage', () => {
 
   it.skip('Import Account and verify passphrase is not saved in localstorage', () => {
     // Import Account process executed
-    cy.importAccount(randomPIN)
+    cy.importAccount(randomPIN, recoverySeed)
 
     //Wait until main page is loaded after importing account
     cy.contains('sadad', { timeout: 60000 }).should('be.visible')

--- a/integration/mobiles-responsiveness.js
+++ b/integration/mobiles-responsiveness.js
@@ -7,6 +7,8 @@ const randomStatus = faker.lorem.word() // generate random status
 const filepathCorrect = 'images/logo.png'
 const randomNumber = faker.datatype.number() // generate random number
 const randomMessage = faker.lorem.sentence() // generate random sentence
+const recoverySeed =
+  'boring over tilt regret diamond rubber example there fire roof sheriff always{enter}'
 
 describe('Run responsiveness tests on several devices', () => {
   Cypress.config('pageLoadTimeout', 180000) //adding more time for pageLoadTimeout only for this spec
@@ -42,7 +44,7 @@ describe('Run responsiveness tests on several devices', () => {
 
     it(`Import Account on ${item.description}`, () => {
       cy.viewport(item.width, item.height)
-      cy.importAccount(randomPIN)
+      cy.importAccount(randomPIN, recoverySeed)
     })
 
     it(`Chat Features on ${item.description}`, () => {

--- a/integration/pair-chat/chat-first-user.js
+++ b/integration/pair-chat/chat-first-user.js
@@ -1,0 +1,46 @@
+const faker = require('faker')
+const recoverySeed =
+  'core radio verb scout shuffle moment pottery maple need ostrich train around{enter}'
+const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate random PIN
+const redirectedURL = 'http://localhost:3000/#/auth/unlock' // URL redirected from root
+const longMessage = faker.lorem.words(50) // generate random sentence
+
+describe('Chat features with two accounts at the same time - First User', () => {
+  before(() => {
+    //Visit root page
+    cy.window().then((win) => {
+      win.sessionStorage.clear()
+    })
+    cy.visit('/')
+    cy.url().then(($url) => {
+      if (!($url === redirectedURL)) {
+        cy.clearLocalStorage()
+        cy.clearCookies()
+        cy.wait(100)
+        cy.visit('/')
+      }
+    })
+
+    //Import account
+    cy.url().should('contain', '#/auth/unlock')
+    cy.get('[data-cy=add-input]')
+      .should('be.visible')
+      .type(randomPIN, { log: false }, { force: true })
+    cy.get('[data-cy=submit-input]').click()
+    cy.contains('Import Account', { timeout: 60000 }).click()
+    cy.get('[data-cy=add-passphrase]')
+      .should('be.visible')
+      .type(recoverySeed, { log: false }, { force: true })
+    cy.contains('Recover Account').click()
+    Cypress.on('uncaught:exception', (err, runnable) => false) // temporary until AP-48 gets fixed
+    cy.contains('Linking Satellites...', { timeout: 300000 }).should(
+      'not.exist',
+    )
+  })
+
+  it('Type a long message in chat bar without sending it', () => {
+    //Validate Chat Screen is loaded
+    cy.contains('Chat User A', { timeout: 300000 }).should('be.visible')
+    cy.get('.messageuser').should('be.visible').type(longMessage)
+  })
+})

--- a/integration/pair-chat/chat-second-user.js
+++ b/integration/pair-chat/chat-second-user.js
@@ -1,0 +1,41 @@
+const faker = require('faker')
+const recoverySeed =
+  'festival drastic visual aisle noble off cousin stairs arm seat agent table{enter}'
+const randomPIN = faker.internet.password(7, false, /[A-Z]/, 'test') // generate random PIN
+const redirectedURL = 'http://localhost:3000/#/auth/unlock' // URL redirected from root
+
+describe('Chat features with two accounts at the same time - Second User', () => {
+  before(() => {
+    //Visit root page
+    cy.window().then((win) => {
+      win.sessionStorage.clear()
+    })
+    cy.visit('/')
+    cy.url().then(($url) => {
+      if (!($url === redirectedURL)) {
+        cy.clearLocalStorage()
+        cy.clearCookies()
+        cy.wait(100)
+        cy.visit('/')
+      }
+    })
+
+    //Import account
+    cy.url().should('contain', '#/auth/unlock')
+    cy.get('[data-cy=add-input]')
+      .should('be.visible')
+      .type(randomPIN, { log: false }, { force: true })
+    cy.get('[data-cy=submit-input]').click()
+    cy.contains('Import Account', { timeout: 60000 }).click()
+    cy.get('[data-cy=add-passphrase]')
+      .should('be.visible')
+      .type(recoverySeed, { log: false }, { force: true })
+    cy.contains('Recover Account').click()
+    Cypress.on('uncaught:exception', (err, runnable) => false) // temporary until AP-48 gets fixed
+  })
+
+  it('Validate that is typing message is displayed', () => {
+    cy.contains('Chat User B', { timeout: 300000 }).should('be.visible')
+    cy.contains('typing', { timeout: 180000 }).should('be.visible')
+  })
+})

--- a/support/commands.js
+++ b/support/commands.js
@@ -175,7 +175,7 @@ Cypress.Commands.add('createAccountSubmit', () => {
 
 //Import Account Commands
 
-Cypress.Commands.add('importAccount', (pin) => {
+Cypress.Commands.add('importAccount', (pin, recoverySeed) => {
   cy.visitRootPage()
   cy.url().should('contain', '#/auth/unlock')
   cy.get('[data-cy=add-input]')
@@ -185,11 +185,7 @@ Cypress.Commands.add('importAccount', (pin) => {
   cy.contains('Import Account', { timeout: 60000 }).click()
   cy.get('[data-cy=add-passphrase]')
     .should('be.visible')
-    .type(
-      'boring over tilt regret diamond rubber example there fire roof sheriff always{enter}',
-      { log: false },
-      { force: true },
-    )
+    .type(recoverySeed, { log: false }, { force: true })
   cy.contains('Recover Account').click()
   Cypress.on('uncaught:exception', (err, runnable) => false) // temporary until AP-48 gets fixed
 })
@@ -266,6 +262,36 @@ Cypress.Commands.add(
     cy.contains(messageEdited)
   },
 )
+
+Cypress.Commands.add('chatFeaturesSendGlyph', () => {
+  cy.get('#glyph-toggle').click()
+  cy.get('.pack-list > .is-text').should('contain', 'Try using some glyphs')
+  cy.get('.glyph-item').first().click()
+  cy.get('.messageuser').click().type('{enter}')
+})
+
+Cypress.Commands.add('chatFeaturesSendImage', (imagePath) => {
+  cy.get('#quick-upload').selectFile(imagePath, {
+    force: true,
+  })
+  cy.get('.file-item').should('be.visible')
+  cy.get('.file-info > .title').should('contain', 'logo.png')
+  cy.contains('Scanning', { timeout: 120000 }).should('not.exist')
+  cy.get('.thumbnail').should('be.visible')
+  cy.get('.messageuser').type('{enter}')
+  cy.get('.thumbnail', { timeout: 120000 }).should('not.exist')
+})
+
+Cypress.Commands.add('chatFeaturesSendFile', (filePath) => {
+  cy.get('#quick-upload').selectFile(filePath, {
+    force: true,
+  })
+  cy.get('.file-item').should('be.visible')
+  cy.get('.file-info > .title').should('contain', 'test-file.txt')
+  cy.get('.preview', { timeout: 120000 }).should('exist')
+  cy.get('.messageuser').type('{enter}')
+  cy.get('.preview', { timeout: 120000 }).should('not.exist')
+})
 
 //Version Release Notes Commands
 


### PR DESCRIPTION
**What this PR does** 📖
- Add new cypress commands for sending glyphs, files and images
- Modified importAccount command to use recoverySeed as a parameter, so it can be used with different accounts
- Add a fixture .txt file for testing file sharing
- Add chat-pair-features.js which includes the validations required for the ticket AP-714
- Add two scripts chat-first-user.js and chat-second-user.js to load two accounts at the same time and test the "typing" indicator

**Which issue(s) this PR fixes** 🔨
AP-714

**Special notes for reviewers** 🗒️
Another PR into the Core-PWA will be send to add the new data-cy locators, cypress.json files and package.json changes needed to run two cypress instances at the same time

**Additional comments** 🎤

**Cypress Video** 📺
Chat features between two accounts:
https://user-images.githubusercontent.com/35935591/157735118-bb127395-b39f-4a30-872c-67bde814f81a.mp4

Chat first user running at the same time as chat second user:
https://user-images.githubusercontent.com/35935591/157735094-584578fe-21dd-4b6f-906b-159592b43f02.mp4

Chat second user running at the same time as chat first user:
https://user-images.githubusercontent.com/35935591/157735123-028deace-cc0b-4703-a5ff-88cf08720c13.mp4






